### PR TITLE
ci: harden larkspur ferry validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,5 +15,9 @@ jobs:
     env:
       SKIP_XCODE_BUILD: "1"
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
       - run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Repository purpose
+
+`garethpaul/Larkspur-Ferry` is an Apple platform application or Swift sample. iOS App Larkspur Ferry
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+- `Podfile` - CocoaPods dependency definition
+- `Larkspur Ferry.xcodeproj` - Xcode project
+- `Larkspur Ferry.xcworkspace` - Xcode workspace
+- `Larkspur Ferry` - repository source or sample assets
+- `Larkspur FerryUITests` - repository source or sample assets
+- `Screenshots` - repository source or sample assets
+
+## Development commands
+
+- Install dependencies: `pod install`
+- Full baseline: `make check`
+- Local Apple development: `open Larkspur Ferry.xcworkspace`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Language mix noted in the README: Swift (10), shell (1).
+- Use the CocoaPods workspace when present; update `Podfile.lock` only with an intentional dependency change.
+- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+
+## Testing guidance
+
+- Test-related files detected: `Larkspur Ferry.xcodeproj/xcshareddata/xcschemes/Larkspur FerryUITests.xcscheme`, `Larkspur FerryUITests/Larkspur_FerryUITests.swift`
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- The app uses the documented HTTPS ferry API endpoint in `Larkspur Ferry/API.swift`.
+- Keep API credentials, signing files, local CocoaPods output, and generated app data out of git if any are introduced later.
+- Location is requested only for in-app ferry direction assistance and should fall back to schedule loading when unavailable.
+- Do not add force-unwrapped API payloads, force-unwrapped location data, or app debug logging for transit/location failures.
+- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- Run `make lint`, `make test`, `make build`, and `make check` before pushing Swift, build-script, Podfile, storyboard, plist, asset, or security documentation changes.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,9 @@
 
 - Added uncached 10-second ferry requests with HTTP status and JSON content-type
   validation before response parsing.
-- Added pinned, read-only macOS hosted project validation with an explicit
-  `SKIP_XCODE_BUILD=1` boundary around obsolete CocoaPods and simulator work.
+- Added pinned, credential-free, read-only macOS hosted project validation with
+  an explicit `SKIP_XCODE_BUILD=1` boundary around obsolete CocoaPods and
+  simulator work.
 - Preserved the last known ferry pin during failed map-location refresh
   responses until a successful refresh can replace it.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - The `lint`, `test`, and `build` targets intentionally alias the existing
   check path so the standard local gate commands stay available while preserving
   the guarded CocoaPods/Xcode skip behavior on hosts without that toolchain.
-- Pinned `macos-15` GitHub Actions runs `make check` with
+- Pinned, credential-free `macos-15` GitHub Actions runs `make check` with
   `SKIP_XCODE_BUILD=1` and parses `Larkspur Ferry.xcodeproj` using
   `xcodebuild -list`. This hosted validation does not install pods, call the
   ferry API, request location, build or sign the app, run a simulator, or

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,10 @@ Helpful reports include:
 - Failed map-location refresh responses should preserve the last known ferry
   pin until a successful refresh can replace it.
 - Run `make check` after changing Swift sources, build scripts, Podfile metadata, plists, storyboards, assets, generated-output ignores, or security documentation.
-- The pinned macOS workflow uses `SKIP_XCODE_BUILD=1` and only parses project
-  metadata; it does not install pods, call the ferry API, request location,
-  build or sign the app, run a simulator, or execute UI tests.
+- The pinned macOS workflow disables checkout credential persistence, uses
+  read-only permissions, and sets `SKIP_XCODE_BUILD=1` to parse project metadata
+  only; it does not install pods, call the ferry API, request location, build or
+  sign the app, run a simulator, or execute UI tests.
 - Review found external API integrations or credential-adjacent configuration; changes in those areas should receive security-focused review before merge.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found mobile permission or privacy-sensitive data handling; changes in those areas should receive security-focused review before merge.

--- a/VISION.md
+++ b/VISION.md
@@ -36,8 +36,9 @@ Priority:
 - Keep failed map-location refresh responses from clearing the last known ferry pin
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
-- Keep hosted project validation pinned and read-only on macOS through
-  structural project parsing and the explicit `SKIP_XCODE_BUILD=1` boundary
+- Keep hosted project validation pinned, credential-free, and read-only on
+  macOS through structural project parsing and the explicit
+  `SKIP_XCODE_BUILD=1` boundary
 - Maintain screenshot, build script, and UI test context
 - Avoid committing private endpoints, keys, or generated signing files
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -75,6 +75,7 @@ def main():
     required_files = [
         ".gitignore",
         ".github/workflows/check.yml",
+        "AGENTS.md",
         ".travis.yml",
         "CHANGES.md",
         "Makefile",
@@ -163,6 +164,7 @@ def main():
     vision = read("VISION.md")
     security = read("SECURITY.md")
     changes = read("CHANGES.md")
+    agents = read("AGENTS.md")
     makefile = read("Makefile")
     overview = read("docs/readme-overview.svg")
     gitignore = read(".gitignore")
@@ -376,6 +378,12 @@ def main():
     require("make check" in security and "location" in security.lower() and "API" in security,
             "SECURITY must document location/API static guardrails",
             failures)
+    require("pod install" in agents and "Larkspur Ferry.xcworkspace" in agents and
+            "make lint" in agents and "make test" in agents and "make build" in agents and
+            "make check" in agents and "force-unwrapped API payloads" in agents and
+            "location data" in agents,
+            "AGENTS.md must preserve CocoaPods, verification, API, and location guardrails",
+            failures)
     require("build.sh" in changes and "force-unwrapping" in changes and ".DS_Store" in changes and "map refresh timer" in changes and "single-shot location" in changes,
             "CHANGES must record build, force unwrap, generated metadata, timer lifecycle, and location lookup hardening",
             failures)
@@ -436,12 +444,25 @@ def main():
     require("status: completed" in validated_response_plan and "10-second" in validated_response_plan,
             "validated ferry response plan must be marked completed",
             failures)
-    require("permissions:\n  contents: read" in workflow and "cancel-in-progress: true" in workflow and
+    actions = re.findall(r"(?m)^\s*(?:-\s*)?uses:\s*(\S+)(?:\s+#.*)?$", workflow)
+    checkout_step = re.search(
+        r"(?m)^      - name: Check out repository\n"
+        r"        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10\n"
+        r"        with:\n"
+        r"          persist-credentials: false\n",
+        workflow,
+    )
+    require(checkout_step is not None and
+            actions == ["actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"] and
+            workflow.count("permissions:") == 1 and
+            workflow.count("persist-credentials:") == 1 and
+            re.search(r"(?m)^\s+[A-Za-z-]+:\s+write\s*$", workflow) is None and
+            "permissions:\n  contents: read" in workflow and "cancel-in-progress: true" in workflow and
             "runs-on: macos-15" in workflow and "timeout-minutes: 10" in workflow and
             'SKIP_XCODE_BUILD: "1"' in workflow and
             "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow and
             "run: make check" in workflow,
-            "Check workflow must stay pinned, read-only, bounded, and structural-only",
+            "Check workflow must use only pinned, credential-free checkout with singular read-only permissions and bounded structural validation",
             failures)
 
     if shutil.which("xcodebuild"):


### PR DESCRIPTION
## Summary

Preserve repository-specific engineering guidance and harden the hosted Larkspur Ferry validation boundary without invoking the legacy CocoaPods build, live ferry API, location services, signing, or simulator UI tests.

## Baseline

This is a legacy Swift 3 and iOS 9 ferry sample using CocoaPods, Alamofire 4.3.0, location services, and a live ferry API. Portable checks can enforce API transport, response validation, workflow, privacy, project-setting, and documentation contracts, while full behavior requires CocoaPods, Xcode, signing, network access, location input, and simulator or device execution.

## Improvements
- add `AGENTS.md` with the CocoaPods workspace, verification commands, API safety rules, and location privacy constraints
- disable checkout credential persistence while retaining immutable checkout pinning and read-only workflow permissions
- require exactly the expected pinned action, one permission block, one credential setting, bounded execution, and the structural-only Xcode boundary
- keep documentation aligned with the credential-free hosted validation contract

The branch also incorporates current `master`, including defensive ferry response validation for HTTP status, JSON content type, cache bypass, and a ten-second timeout.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- Python AST, GitHub Actions YAML, and POSIX shell parsing
- `git diff --check`, conflict-marker scan, credential scan, and generated-bytecode assertions
- 20 isolated hostile mutations rejected across ferry API transport checks, workflow permissions/actions/credentials, the hosted build boundary, Swift project settings, agent guidance, and plan status

Local Linux validation skipped CocoaPods/Xcode execution because those tools are unavailable. Hosted `macos-15` project parsing is the authoritative Apple-toolchain signal for this PR.

## Risk
The project remains on Swift 3, iOS 9, and Alamofire 4.3.0 while current Alamofire is 5.12.0. A dependency upgrade requires a dedicated Swift/platform migration and should not be combined with this focused workflow hardening.

## Follow-Ups

- Reconstruct the CocoaPods workspace on a compatible macOS/Xcode host and exercise project build, signing, launch, and simulator/device UI flows.
- Validate ferry API success, non-2xx, content-type, malformed JSON, timeout, cache, and offline behavior against a controlled endpoint.
- Exercise location authorization, denial, updates, background transitions, and privacy-sensitive logging on a device or simulator.
- Migrate Swift, the iOS deployment target, CocoaPods, and Alamofire in a separate compatibility-focused change.

## Post-Deploy Monitoring & Validation

No production monitoring is required because this repository is a legacy sample and the PR does not deploy an application. For 24 hours after merge, the maintainer should verify `Check / baseline` remains green on pushes and pull requests; any workflow permission expansion, action-pin drift, project parse failure, or live network/location access in CI should trigger reverting the workflow hardening commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
