### PR TITLE
fix: reject stale same-origin schedules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-16
+
+- Added a revision-aware schedule response policy so tap-away-and-back callbacks
+  cannot publish an older same-origin schedule.
+- Added a standalone Swift harness that executes the production policy across
+  eight deterministic origin and revision cases from every Make gate.
+
 ## 2026-06-15
 
 - Rejected a stale geocoder completion after a newer manual ferry direction

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Added a revision-aware ferry-location response policy so an older overlapping
   callback cannot replace a newer map position or publish after disappearance.
+- Added finite coordinate domain validation so numeric but invalid ferry
+  latitude and longitude values cannot reach MapKit.
 
 ## 2026-06-16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Added a revision-aware ferry-location response policy so an older overlapping
+  callback cannot replace a newer map position or publish after disappearance.
+
 ## 2026-06-16
 
 - Added a revision-aware schedule response policy so tap-away-and-back callbacks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
 - Added a revision-aware schedule response policy so tap-away-and-back callbacks
   cannot publish an older same-origin schedule.
 - Added a standalone Swift harness that executes the production policy across
-  eight deterministic origin and revision cases from every Make gate.
+  nine deterministic origin, direction revision, and request revision cases from
+  every Make gate.
 
 ## 2026-06-15
 

--- a/Larkspur Ferry.xcodeproj/project.pbxproj
+++ b/Larkspur Ferry.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */; };
+		A17061711C04445D009A6111 /* LocationResponsePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17061721C04445D009A6111 /* LocationResponsePolicy.swift */; };
 		886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886EA3C31C1F918F00E864A0 /* FerryCell.swift */; };
 		8899B7881C037F6D00512759 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8899B7871C037F6D00512759 /* CoreLocation.framework */; };
 		889C7DD21C04445D009A6111 /* Ferry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C7DD11C04445D009A6111 /* Ferry.swift */; };
@@ -37,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleResponsePolicy.swift; sourceTree = "<group>"; };
+		A17061721C04445D009A6111 /* LocationResponsePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationResponsePolicy.swift; sourceTree = "<group>"; };
 		3AFC5927A49D0AA110B3C5FB /* Pods-Larkspur Ferry.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Larkspur Ferry.release.xcconfig"; path = "Pods/Target Support Files/Pods-Larkspur Ferry/Pods-Larkspur Ferry.release.xcconfig"; sourceTree = "<group>"; };
 		886EA3C31C1F918F00E864A0 /* FerryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FerryCell.swift; sourceTree = "<group>"; };
 		8899B7871C037F6D00512759 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -124,6 +126,7 @@
 			children = (
 				88CBBCE81C037B1F000D263E /* AppDelegate.swift */,
 				A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */,
+				A17061721C04445D009A6111 /* LocationResponsePolicy.swift */,
 				88CBBCEA1C037B1F000D263E /* ViewController.swift */,
 				889C7DD11C04445D009A6111 /* Ferry.swift */,
 				88C12B591A54CCC9006DA21E /* API.swift */,
@@ -311,6 +314,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */,
+				A17061711C04445D009A6111 /* LocationResponsePolicy.swift in Sources */,
 				889C7DD21C04445D009A6111 /* Ferry.swift in Sources */,
 				88FD06CB1C0A7EC500EA6A9F /* Extensions.swift in Sources */,
 				886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */,

--- a/Larkspur Ferry.xcodeproj/project.pbxproj
+++ b/Larkspur Ferry.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */; };
 		886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886EA3C31C1F918F00E864A0 /* FerryCell.swift */; };
 		8899B7881C037F6D00512759 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8899B7871C037F6D00512759 /* CoreLocation.framework */; };
 		889C7DD21C04445D009A6111 /* Ferry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C7DD11C04445D009A6111 /* Ferry.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleResponsePolicy.swift; sourceTree = "<group>"; };
 		3AFC5927A49D0AA110B3C5FB /* Pods-Larkspur Ferry.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Larkspur Ferry.release.xcconfig"; path = "Pods/Target Support Files/Pods-Larkspur Ferry/Pods-Larkspur Ferry.release.xcconfig"; sourceTree = "<group>"; };
 		886EA3C31C1F918F00E864A0 /* FerryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FerryCell.swift; sourceTree = "<group>"; };
 		8899B7871C037F6D00512759 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -121,6 +123,7 @@
 			isa = PBXGroup;
 			children = (
 				88CBBCE81C037B1F000D263E /* AppDelegate.swift */,
+				A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */,
 				88CBBCEA1C037B1F000D263E /* ViewController.swift */,
 				889C7DD11C04445D009A6111 /* Ferry.swift */,
 				88C12B591A54CCC9006DA21E /* API.swift */,
@@ -307,6 +310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */,
 				889C7DD21C04445D009A6111 /* Ferry.swift in Sources */,
 				88FD06CB1C0A7EC500EA6A9F /* Extensions.swift in Sources */,
 				886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */,

--- a/Larkspur Ferry/API.swift
+++ b/Larkspur Ferry/API.swift
@@ -27,7 +27,8 @@ final class API {
                 let latString = result["lat"] as? String,
                 let lngString = result["lng"] as? String,
                 let lat = latString.toDouble(),
-                let lng = lngString.toDouble() else {
+                let lng = lngString.toDouble(),
+                isValidFerryCoordinate(latitude: lat, longitude: lng) else {
                     completion(nil)
                     return
             }

--- a/Larkspur Ferry/LocationResponsePolicy.swift
+++ b/Larkspur Ferry/LocationResponsePolicy.swift
@@ -1,0 +1,4 @@
+func acceptsFerryLocationResponse(requestedRevision: Int,
+                                  currentRevision: Int) -> Bool {
+    return requestedRevision == currentRevision
+}

--- a/Larkspur Ferry/LocationResponsePolicy.swift
+++ b/Larkspur Ferry/LocationResponsePolicy.swift
@@ -2,3 +2,12 @@ func acceptsFerryLocationResponse(requestedRevision: Int,
                                   currentRevision: Int) -> Bool {
     return requestedRevision == currentRevision
 }
+
+func isValidFerryCoordinate(latitude: Double, longitude: Double) -> Bool {
+    guard latitude.isFinite && longitude.isFinite else {
+        return false
+    }
+
+    return (-90.0...90.0).contains(latitude) &&
+        (-180.0...180.0).contains(longitude)
+}

--- a/Larkspur Ferry/MapViewController.swift
+++ b/Larkspur Ferry/MapViewController.swift
@@ -19,6 +19,7 @@ class MapViewController: UIViewController, MKMapViewDelegate {
     let regionRadius: CLLocationDistance = 4200
     var locationRefreshTimer: Timer?
     private var isMapVisible = false
+    private var locationRequestRevision = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,6 +37,7 @@ class MapViewController: UIViewController, MKMapViewDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         isMapVisible = false
+        locationRequestRevision += 1
         locationRefreshTimer?.invalidate()
         locationRefreshTimer = nil
     }
@@ -47,6 +49,8 @@ class MapViewController: UIViewController, MKMapViewDelegate {
     }
 
     func getLocation() {
+        locationRequestRevision += 1
+        let requestedLocationRevision = locationRequestRevision
         API.sharedInstance.getLocation(completion: { [weak self] (location) -> Void in
             guard let location = location else {
                 return
@@ -54,7 +58,11 @@ class MapViewController: UIViewController, MKMapViewDelegate {
 
             DispatchQueue.main.async {
                 guard let viewController = self,
-                    viewController.isMapVisible else {
+                    viewController.isMapVisible,
+                    acceptsFerryLocationResponse(
+                        requestedRevision: requestedLocationRevision,
+                        currentRevision: viewController.locationRequestRevision
+                    ) else {
                     return
                 }
 

--- a/Larkspur Ferry/ScheduleResponsePolicy.swift
+++ b/Larkspur Ferry/ScheduleResponsePolicy.swift
@@ -1,10 +1,13 @@
 func acceptsFerryScheduleResponse(requestedFrom: String,
                                   requestedDirectionRevision: Int,
+                                  requestedScheduleRequestRevision: Int,
                                   currentFrom: String,
-                                  currentDirectionRevision: Int) -> Bool {
+                                  currentDirectionRevision: Int,
+                                  currentScheduleRequestRevision: Int) -> Bool {
     let knownOrigin = requestedFrom == "Larkspur" || requestedFrom == "San Francisco"
 
     return knownOrigin &&
         requestedFrom == currentFrom &&
-        requestedDirectionRevision == currentDirectionRevision
+        requestedDirectionRevision == currentDirectionRevision &&
+        requestedScheduleRequestRevision == currentScheduleRequestRevision
 }

--- a/Larkspur Ferry/ScheduleResponsePolicy.swift
+++ b/Larkspur Ferry/ScheduleResponsePolicy.swift
@@ -1,0 +1,10 @@
+func acceptsFerryScheduleResponse(requestedFrom: String,
+                                  requestedDirectionRevision: Int,
+                                  currentFrom: String,
+                                  currentDirectionRevision: Int) -> Bool {
+    let knownOrigin = requestedFrom == "Larkspur" || requestedFrom == "San Francisco"
+
+    return knownOrigin &&
+        requestedFrom == currentFrom &&
+        requestedDirectionRevision == currentDirectionRevision
+}

--- a/Larkspur Ferry/ViewController.swift
+++ b/Larkspur Ferry/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
     var f = "Larkspur"
     var directionRevision = 0
     var locationLookupDirectionRevision = 0
+    var scheduleRequestRevision = 0
     
     var locationUpdated = false
     
@@ -133,16 +134,20 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
     // Get the Boats from the API and then reload the table
     func getBoats() {
         // Get the times for the ferry
+        scheduleRequestRevision += 1
         let requestedFrom = f
         let requestedDirectionRevision = directionRevision
+        let requestedScheduleRequestRevision = scheduleRequestRevision
         API.sharedInstance.getTimes(from: requestedFrom) { [weak self] (boats) -> Void in
             DispatchQueue.main.async {
                 guard let viewController = self,
                     acceptsFerryScheduleResponse(
                         requestedFrom: requestedFrom,
                         requestedDirectionRevision: requestedDirectionRevision,
+                        requestedScheduleRequestRevision: requestedScheduleRequestRevision,
                         currentFrom: viewController.f,
-                        currentDirectionRevision: viewController.directionRevision
+                        currentDirectionRevision: viewController.directionRevision,
+                        currentScheduleRequestRevision: viewController.scheduleRequestRevision
                     ) else {
                     return
                 }

--- a/Larkspur Ferry/ViewController.swift
+++ b/Larkspur Ferry/ViewController.swift
@@ -134,10 +134,16 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
     func getBoats() {
         // Get the times for the ferry
         let requestedFrom = f
+        let requestedDirectionRevision = directionRevision
         API.sharedInstance.getTimes(from: requestedFrom) { [weak self] (boats) -> Void in
             DispatchQueue.main.async {
                 guard let viewController = self,
-                    viewController.f == requestedFrom else {
+                    acceptsFerryScheduleResponse(
+                        requestedFrom: requestedFrom,
+                        requestedDirectionRevision: requestedDirectionRevision,
+                        currentFrom: viewController.f,
+                        currentDirectionRevision: viewController.directionRevision
+                    ) else {
                     return
                 }
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SWIFTC ?= swiftc
 
 .PHONY: build check lint test
 
 lint test build: check
 
 check:
+	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \
+	else \
+		echo "swiftc unavailable; executable schedule response tests skipped"; \
+	fi
 	python3 "$(ROOT)/scripts/check-baseline.py"
 	cd "$(ROOT)" && ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ lint test build: check
 check:
 	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \
 	else \
-		echo "swiftc unavailable; executable schedule response tests skipped"; \
+		echo "swiftc unavailable; executable response policy tests skipped"; \
 	fi
 	python3 "$(ROOT)/scripts/check-baseline.py"
 	cd "$(ROOT)" && ./build.sh

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   only successful `application/json` responses before parsing.
 - Schedule table and map API callbacks use main-thread UI updates before
   mutating UIKit or MapKit state.
+- Revision-aware ferry-location callbacks ignore older overlapping responses
+  and callbacks invalidated when the map begins disappearing.
 - A stale schedule response is ignored after the user selects the opposite
   ferry direction.
 - A revision-aware schedule response guard also rejects an older callback after
@@ -83,9 +85,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 ## Testing and Verification
 
 - `make lint`, `make test`, `make build`, and `make check` execute the production
-  schedule response policy when `swiftc` is available, then run
+  schedule and ferry-location response policies when `swiftc` is available,
+  then run
   `scripts/check-baseline.py` and the guarded `build.sh` path. The checker
-  preserves the eight-case harness, app-target wiring, API and location
+  preserves both executable harnesses, app-target wiring, API and location
   guardrails, project metadata, and documentation contracts.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
@@ -95,10 +98,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   the guarded CocoaPods/Xcode skip behavior on hosts without that toolchain.
 - Pinned, credential-free `macos-15` GitHub Actions runs `make check` with
   `SKIP_XCODE_BUILD=1` and parses `Larkspur Ferry.xcodeproj` using
-  `xcodebuild -list`. It compiles and executes the revision-aware schedule
-  response policy without installing pods, calling the ferry API, requesting
-  location, building or signing the app, running a simulator, or executing the
-  legacy UI tests. Checkout credentials are not persisted after source retrieval.
+  `xcodebuild -list`. It compiles and executes the revision-aware schedule and
+  ferry-location response policies without installing pods, calling the ferry
+  API, requesting location, building or signing the app, running a simulator,
+  or executing the legacy UI tests. Checkout credentials are not persisted
+  after source retrieval.
 - Xcode's test action or `xcodebuild test` with the appropriate scheme and destination
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - The initial direction lookup is a single-shot location flow; unavailable, empty, or failed CoreLocation/geocoder data stops location updates before falling back to schedule loading.
 - API request parameters use deterministic query ordering after percent encoding.
 - Ferry API latitude and longitude strings use locale-independent coordinate parsing.
+- Parsed ferry coordinates must also be finite and remain within valid latitude
+  and longitude bounds before they can reach MapKit.
 - Schedule table times use POSIX schedule time parsing for fixed-format ferry API values.
 - Live ferry requests bypass cached data, time out after 10 seconds, and accept
   only successful `application/json` responses before parsing.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - A stale schedule response is ignored after the user selects the opposite
   ferry direction.
 - A revision-aware schedule response guard also rejects an older callback after
-  the user taps away from and back to the same ferry origin.
+  the user taps away from and back to the same ferry origin, and rejects older
+  same-origin callbacks when a newer schedule request is already active.
 - A stale geocoder completion is ignored after any newer manual direction
   change, including tap-away-and-back sequences.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `garethpaul/Larkspur-Ferry` is an Apple platform application or Swift sample. iOS App Larkspur Ferry
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (10), shell (1).
+This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (12), shell (2).
 
 ## Repository Contents
 
@@ -75,12 +75,18 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   mutating UIKit or MapKit state.
 - A stale schedule response is ignored after the user selects the opposite
   ferry direction.
+- A revision-aware schedule response guard also rejects an older callback after
+  the user taps away from and back to the same ferry origin.
 - A stale geocoder completion is ignored after any newer manual direction
   change, including tap-away-and-back sequences.
 
 ## Testing and Verification
 
-- `make lint`, `make test`, `make build`, and `make check` run `scripts/check-baseline.py` and the guarded `build.sh` path. The checker verifies build-script syntax, plist/storyboard/asset parsing, Podfile lock metadata, API parsing guardrails, deterministic query parameter encoding, locale-independent coordinate parsing, POSIX schedule time parsing, main-thread UI updates, stale schedule response rejection, single-shot location fallbacks, map refresh timer lifecycle handling, ferry annotation refresh handling, failed map-location refresh handling, and generated metadata ignores.
+- `make lint`, `make test`, `make build`, and `make check` execute the production
+  schedule response policy when `swiftc` is available, then run
+  `scripts/check-baseline.py` and the guarded `build.sh` path. The checker
+  preserves the eight-case harness, app-target wiring, API and location
+  guardrails, project metadata, and documentation contracts.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
   `make -f /path/to/Larkspur-Ferry/Makefile check`.
@@ -89,10 +95,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   the guarded CocoaPods/Xcode skip behavior on hosts without that toolchain.
 - Pinned, credential-free `macos-15` GitHub Actions runs `make check` with
   `SKIP_XCODE_BUILD=1` and parses `Larkspur Ferry.xcodeproj` using
-  `xcodebuild -list`. This hosted validation does not install pods, call the
-  ferry API, request location, build or sign the app, run a simulator, or
-  execute UI tests. Checkout credentials are not persisted after source
-  retrieval.
+  `xcodebuild -list`. It compiles and executes the revision-aware schedule
+  response policy without installing pods, calling the ferry API, requesting
+  location, building or signing the app, running a simulator, or executing the
+  legacy UI tests. Checkout credentials are not persisted after source retrieval.
 - Xcode's test action or `xcodebuild test` with the appropriate scheme and destination
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,8 @@ Helpful reports include:
   and validate HTTP success plus `application/json` before parsing.
 - Deterministic query parameter encoding should run after percent encoding so request construction is stable during review.
 - Locale-independent coordinate parsing should handle ferry API latitude and longitude strings consistently across device regions.
+- Ferry coordinates must be finite and remain within valid latitude and
+  longitude bounds before constructing location or map state.
 - POSIX schedule time parsing should handle fixed-format ferry API departure strings consistently across device regions.
 - Main-thread UI updates should be preserved for schedule table and MapKit callbacks so asynchronous API completions do not mutate UIKit or MapKit state off the main queue.
 - Revision-aware ferry-location callbacks must reject older overlapping responses and callbacks invalidated when the map begins disappearing before mutating MapKit state.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ Helpful reports include:
 - Revision-aware ferry-location callbacks must reject older overlapping responses and callbacks invalidated when the map begins disappearing before mutating MapKit state.
 - A stale schedule response must not replace the table after the user selects the opposite ferry direction.
 - A revision-aware schedule response guard must also reject older callbacks
-  after a tap-away-and-back sequence returns to the same origin.
+  after a tap-away-and-back sequence returns to the same origin, or after a
+  newer same-origin schedule request is already active.
 - The initial direction lookup should remain a single-shot location flow that stops CoreLocation updates before empty-sample or failure fallback schedule loading.
 - Location-derived direction state should align the canonical schedule origin
   before direction images or schedule requests are published.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Helpful reports include:
 - POSIX schedule time parsing should handle fixed-format ferry API departure strings consistently across device regions.
 - Main-thread UI updates should be preserved for schedule table and MapKit callbacks so asynchronous API completions do not mutate UIKit or MapKit state off the main queue.
 - A stale schedule response must not replace the table after the user selects the opposite ferry direction.
+- A revision-aware schedule response guard must also reject older callbacks
+  after a tap-away-and-back sequence returns to the same origin.
 - The initial direction lookup should remain a single-shot location flow that stops CoreLocation updates before empty-sample or failure fallback schedule loading.
 - Location-derived direction state should align the canonical schedule origin
   before direction images or schedule requests are published.
@@ -44,9 +46,9 @@ Helpful reports include:
   pin until a successful refresh can replace it.
 - Run `make check` after changing Swift sources, build scripts, Podfile metadata, plists, storyboards, assets, generated-output ignores, or security documentation.
 - The pinned macOS workflow uses a credential-free checkout,
-  `SKIP_XCODE_BUILD=1`, and project parsing only; it does not install pods, call
-  the ferry API, request location, build or sign the app, run a simulator, or
-  execute UI tests.
+  `SKIP_XCODE_BUILD=1`, production policy execution, and project parsing; it
+  does not install pods, call the ferry API, request location, build or sign the
+  app, run a simulator, or execute UI tests.
 - Review found external API integrations or credential-adjacent configuration; changes in those areas should receive security-focused review before merge.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found mobile permission or privacy-sensitive data handling; changes in those areas should receive security-focused review before merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,7 @@ Helpful reports include:
 - Locale-independent coordinate parsing should handle ferry API latitude and longitude strings consistently across device regions.
 - POSIX schedule time parsing should handle fixed-format ferry API departure strings consistently across device regions.
 - Main-thread UI updates should be preserved for schedule table and MapKit callbacks so asynchronous API completions do not mutate UIKit or MapKit state off the main queue.
+- Revision-aware ferry-location callbacks must reject older overlapping responses and callbacks invalidated when the map begins disappearing before mutating MapKit state.
 - A stale schedule response must not replace the table after the user selects the opposite ferry direction.
 - A revision-aware schedule response guard must also reject older callbacks
   after a tap-away-and-back sequence returns to the same origin.

--- a/Tests/LocationResponsePolicyTests/main.swift
+++ b/Tests/LocationResponsePolicyTests/main.swift
@@ -1,0 +1,28 @@
+private var failureCount = 0
+
+private func expect(_ requestedRevision: Int,
+                    _ currentRevision: Int,
+                    _ expected: Bool,
+                    _ message: String) {
+    let actual = acceptsFerryLocationResponse(
+        requestedRevision: requestedRevision,
+        currentRevision: currentRevision
+    )
+
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expected), got \(actual)")
+    }
+}
+
+expect(0, 0, true, "initial request")
+expect(7, 7, true, "latest request")
+expect(6, 7, false, "older overlapping request")
+expect(8, 7, false, "noncurrent future request")
+expect(3, 4, false, "disappearance invalidation")
+
+if failureCount > 0 {
+    fatalError("LocationResponsePolicy behavioral tests failed: \(failureCount)")
+}
+
+print("LocationResponsePolicy behavioral tests passed")

--- a/Tests/LocationResponsePolicyTests/main.swift
+++ b/Tests/LocationResponsePolicyTests/main.swift
@@ -15,11 +15,35 @@ private func expect(_ requestedRevision: Int,
     }
 }
 
+private func expectCoordinate(_ latitude: Double,
+                              _ longitude: Double,
+                              _ expected: Bool,
+                              _ message: String) {
+    let actual = isValidFerryCoordinate(latitude: latitude, longitude: longitude)
+
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expected), got \(actual)")
+    }
+}
+
 expect(0, 0, true, "initial request")
 expect(7, 7, true, "latest request")
 expect(6, 7, false, "older overlapping request")
 expect(8, 7, false, "noncurrent future request")
 expect(3, 4, false, "disappearance invalidation")
+
+expectCoordinate(37.79984, -122.38921, true, "normal ferry coordinate")
+expectCoordinate(-90.0, -180.0, true, "minimum coordinate boundaries")
+expectCoordinate(90.0, 180.0, true, "maximum coordinate boundaries")
+expectCoordinate(-90.0001, 0.0, false, "latitude below minimum")
+expectCoordinate(90.0001, 0.0, false, "latitude above maximum")
+expectCoordinate(0.0, -180.0001, false, "longitude below minimum")
+expectCoordinate(0.0, 180.0001, false, "longitude above maximum")
+expectCoordinate(Double.nan, 0.0, false, "NaN latitude")
+expectCoordinate(0.0, Double.nan, false, "NaN longitude")
+expectCoordinate(Double.infinity, 0.0, false, "infinite latitude")
+expectCoordinate(0.0, -Double.infinity, false, "infinite longitude")
 
 if failureCount > 0 {
     fatalError("LocationResponsePolicy behavioral tests failed: \(failureCount)")

--- a/Tests/ScheduleResponsePolicyTests/main.swift
+++ b/Tests/ScheduleResponsePolicyTests/main.swift
@@ -1,0 +1,35 @@
+private var failureCount = 0
+
+private func expect(_ requestedFrom: String,
+                    _ requestedRevision: Int,
+                    _ currentFrom: String,
+                    _ currentRevision: Int,
+                    _ expected: Bool,
+                    _ message: String) {
+    let actual = acceptsFerryScheduleResponse(
+        requestedFrom: requestedFrom,
+        requestedDirectionRevision: requestedRevision,
+        currentFrom: currentFrom,
+        currentDirectionRevision: currentRevision
+    )
+
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expected), got \(actual)")
+    }
+}
+
+expect("Larkspur", 0, "Larkspur", 0, true, "initial Larkspur response")
+expect("San Francisco", 4, "San Francisco", 4, true, "current San Francisco response")
+expect("Larkspur", 1, "San Francisco", 1, false, "changed origin")
+expect("San Francisco", 2, "Larkspur", 2, false, "reverse changed origin")
+expect("Larkspur", 3, "Larkspur", 5, false, "tap-away-and-back stale response")
+expect("San Francisco", 8, "San Francisco", 9, false, "newer same-origin request")
+expect("", 0, "", 0, false, "empty origin")
+expect("Sausalito", 2, "Sausalito", 2, false, "unknown origin")
+
+if failureCount > 0 {
+    fatalError("ScheduleResponsePolicy behavioral tests failed: \(failureCount)")
+}
+
+print("ScheduleResponsePolicy behavioral tests passed")

--- a/Tests/ScheduleResponsePolicyTests/main.swift
+++ b/Tests/ScheduleResponsePolicyTests/main.swift
@@ -2,15 +2,19 @@ private var failureCount = 0
 
 private func expect(_ requestedFrom: String,
                     _ requestedRevision: Int,
+                    _ requestedRequestRevision: Int,
                     _ currentFrom: String,
                     _ currentRevision: Int,
+                    _ currentRequestRevision: Int,
                     _ expected: Bool,
                     _ message: String) {
     let actual = acceptsFerryScheduleResponse(
         requestedFrom: requestedFrom,
         requestedDirectionRevision: requestedRevision,
+        requestedScheduleRequestRevision: requestedRequestRevision,
         currentFrom: currentFrom,
-        currentDirectionRevision: currentRevision
+        currentDirectionRevision: currentRevision,
+        currentScheduleRequestRevision: currentRequestRevision
     )
 
     if actual != expected {
@@ -19,14 +23,15 @@ private func expect(_ requestedFrom: String,
     }
 }
 
-expect("Larkspur", 0, "Larkspur", 0, true, "initial Larkspur response")
-expect("San Francisco", 4, "San Francisco", 4, true, "current San Francisco response")
-expect("Larkspur", 1, "San Francisco", 1, false, "changed origin")
-expect("San Francisco", 2, "Larkspur", 2, false, "reverse changed origin")
-expect("Larkspur", 3, "Larkspur", 5, false, "tap-away-and-back stale response")
-expect("San Francisco", 8, "San Francisco", 9, false, "newer same-origin request")
-expect("", 0, "", 0, false, "empty origin")
-expect("Sausalito", 2, "Sausalito", 2, false, "unknown origin")
+expect("Larkspur", 0, 1, "Larkspur", 0, 1, true, "initial Larkspur response")
+expect("San Francisco", 4, 7, "San Francisco", 4, 7, true, "current San Francisco response")
+expect("Larkspur", 1, 3, "San Francisco", 1, 3, false, "changed origin")
+expect("San Francisco", 2, 4, "Larkspur", 2, 4, false, "reverse changed origin")
+expect("Larkspur", 3, 5, "Larkspur", 5, 6, false, "tap-away-and-back stale response")
+expect("San Francisco", 8, 9, "San Francisco", 9, 10, false, "newer same-origin direction request")
+expect("Larkspur", 6, 11, "Larkspur", 6, 12, false, "newer same-origin schedule request")
+expect("", 0, 1, "", 0, 1, false, "empty origin")
+expect("Sausalito", 2, 4, "Sausalito", 2, 4, false, "unknown origin")
 
 if failureCount > 0 {
     fatalError("ScheduleResponsePolicy behavioral tests failed: \(failureCount)")

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Validate successful JSON ferry responses with a 10-second uncached request
 - Keep API request construction on deterministic query parameter ordering
 - Keep locale-independent coordinate parsing for ferry API latitude and longitude values
+- Reject non-finite and out-of-range ferry coordinates before MapKit publication
 - Keep POSIX schedule time parsing for fixed-format ferry API departure values
 - Keep main-thread UI updates for schedule table and map API callbacks
 - Keep revision-aware ferry-location callbacks that reject older overlapping

--- a/VISION.md
+++ b/VISION.md
@@ -13,10 +13,10 @@ Project context lives in [`README.md`](README.md).
 The goal is to keep the app useful, verifiable, and clear about its data source.
 
 Current baseline: `make lint`, `make test`, `make build`, and `make check` run
-`scripts/check-baseline.py` and the guarded `build.sh` path to verify the build
+the revision-aware schedule response harness, `scripts/check-baseline.py`, and
+the guarded `build.sh` path to verify the production callback decision, build
 script, CocoaPods metadata, Swift API parsing, single-shot location fallbacks,
-storyboards, plists, assets, failed map-location refresh handling, generated
-metadata ignores, and documentation.
+project assets, generated metadata ignores, and documentation.
 
 The current focus is:
 
@@ -30,6 +30,8 @@ Priority:
 - Keep POSIX schedule time parsing for fixed-format ferry API departure values
 - Keep main-thread UI updates for schedule table and map API callbacks
 - Reject a stale schedule response after the user selects a newer direction
+- Execute the revision-aware schedule response guard so tap-away-and-back
+  callbacks from older revisions remain rejected
 - Keep malformed API payloads and unavailable location data from crashing the app
 - Keep initial direction lookup as a single-shot location flow that stops updates before empty-sample or failure fallback
 - Keep location-derived direction state aligned with the canonical schedule
@@ -40,8 +42,9 @@ Priority:
 - Keep failed map-location refresh responses from clearing the last known ferry pin
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
-- Keep hosted project validation pinned, credential-free, and read-only on macOS through
-  structural project parsing and the explicit `SKIP_XCODE_BUILD=1` boundary
+- Keep hosted validation pinned, credential-free, and read-only on macOS through
+  production policy execution, project parsing, and the explicit
+  `SKIP_XCODE_BUILD=1` legacy-build boundary
 - Maintain screenshot, build script, and UI test context
 - Avoid committing private endpoints, keys, or generated signing files
 

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,9 @@ Priority:
 - Keep locale-independent coordinate parsing for ferry API latitude and longitude values
 - Keep POSIX schedule time parsing for fixed-format ferry API departure values
 - Keep main-thread UI updates for schedule table and map API callbacks
+- Keep revision-aware ferry-location callbacks that reject older overlapping
+  responses and callbacks invalidated when the map begins disappearing before
+  publishing MapKit state
 - Reject a stale schedule response after the user selects a newer direction
 - Execute the revision-aware schedule response guard so tap-away-and-back
   callbacks from older revisions remain rejected

--- a/VISION.md
+++ b/VISION.md
@@ -35,7 +35,8 @@ Priority:
   publishing MapKit state
 - Reject a stale schedule response after the user selects a newer direction
 - Execute the revision-aware schedule response guard so tap-away-and-back
-  callbacks from older revisions remain rejected
+  callbacks from older revisions and older same-origin schedule requests remain
+  rejected
 - Keep malformed API payloads and unavailable location data from crashing the app
 - Keep initial direction lookup as a single-shot location flow that stops updates before empty-sample or failure fallback
 - Keep location-derived direction state aligned with the canonical schedule

--- a/docs/plans/2026-06-16-schedule-response-revision-policy.md
+++ b/docs/plans/2026-06-16-schedule-response-revision-policy.md
@@ -1,0 +1,40 @@
+---
+title: Execute schedule response revision policy
+type: reliability
+date: 2026-06-16
+status: completed
+execution: code
+---
+
+# Execute schedule response revision policy
+
+## Goal
+
+Prevent an older ferry schedule callback from publishing after a user toggles
+away from and back to the same origin, and execute that production decision in
+hosted verification without depending on live transit data or the legacy UI
+test stack.
+
+## Requirements
+
+- Accept a schedule callback only when its origin and direction revision both
+  match current controller state.
+- Reject unknown origins and tap-away-and-back callbacks from older revisions.
+- Keep the pure policy in the app target and delegate the callback guard to it.
+- Compile and execute the production policy from every Make gate when `swiftc`
+  is available.
+- Preserve the legacy UI test target as context without claiming it executes.
+
+## Verification Completed
+
+- All four Make gates passed from the repository root.
+- The external absolute Makefile gate passed from `/tmp`.
+- Fake-compiler success, exit-7 failure, signal-143 cleanup, and temporary-build
+  cleanup probes passed for the standalone runner.
+- Eight hostile mutations were rejected across origin validation, revision
+  matching, controller delegation, app-target membership, executable cases,
+  runner cleanup, Make wiring, and completed plan evidence.
+- Shell and Python syntax, project references, executable modes, diff checks,
+  artifact scans, and changed-line credential-pattern scans passed.
+- `swiftc` and Xcode are unavailable on this Linux host, so the hosted
+  pull-request check is the pre-merge authority for production Swift execution.

--- a/docs/plans/2026-06-16-schedule-response-revision-policy.md
+++ b/docs/plans/2026-06-16-schedule-response-revision-policy.md
@@ -36,5 +36,7 @@ test stack.
   runner cleanup, Make wiring, and completed plan evidence.
 - Shell and Python syntax, project references, executable modes, diff checks,
   artifact scans, and changed-line credential-pattern scans passed.
-- `swiftc` and Xcode are unavailable on this Linux host, so the hosted
-  pull-request check is the pre-merge authority for production Swift execution.
+- `swiftc` and Xcode are unavailable on this Linux host. On implementation head
+  `96748de8f936e816096e7addef855198304337b1`, hosted push run `27643518037`
+  and hosted pull-request check run `27643523921` passed; both logs recorded the
+  production policy harness and maintained baseline passing.

--- a/docs/plans/2026-06-16-schedule-response-revision-policy.md
+++ b/docs/plans/2026-06-16-schedule-response-revision-policy.md
@@ -17,9 +17,10 @@ test stack.
 
 ## Requirements
 
-- Accept a schedule callback only when its origin and direction revision both
-  match current controller state.
-- Reject unknown origins and tap-away-and-back callbacks from older revisions.
+- Accept a schedule callback only when its origin, direction revision, and
+  request revision all match current controller state.
+- Reject unknown origins, tap-away-and-back callbacks from older revisions, and
+  older same-origin callbacks when a newer schedule request is already active.
 - Keep the pure policy in the app target and delegate the callback guard to it.
 - Compile and execute the production policy from every Make gate when `swiftc`
   is available.
@@ -31,9 +32,9 @@ test stack.
 - The external absolute Makefile gate passed from `/tmp`.
 - Fake-compiler success, exit-7 failure, signal-143 cleanup, and temporary-build
   cleanup probes passed for the standalone runner.
-- Eight hostile mutations were rejected across origin validation, revision
-  matching, controller delegation, app-target membership, executable cases,
-  runner cleanup, Make wiring, and completed plan evidence.
+- Nine hostile mutations were rejected across origin validation, direction and
+  request revision matching, controller delegation, app-target membership,
+  executable cases, runner cleanup, Make wiring, and completed plan evidence.
 - Shell and Python syntax, project references, executable modes, diff checks,
   artifact scans, and changed-line credential-pattern scans passed.
 - `swiftc` and Xcode are unavailable on this Linux host. On implementation head

--- a/docs/plans/2026-06-17-ferry-coordinate-domain-validation.md
+++ b/docs/plans/2026-06-17-ferry-coordinate-domain-validation.md
@@ -2,7 +2,7 @@
 title: Reject invalid ferry coordinate domains
 type: reliability
 date: 2026-06-17
-status: in_progress
+status: completed
 execution: code
 ---
 
@@ -85,8 +85,25 @@ guidance, and truthful completed-plan evidence against isolated weakening.
 
 ## Work Completed
 
-Pending implementation.
+- Added a pure finite/range predicate to the existing app-target location
+  policy.
+- Required parsed ferry coordinates to pass the predicate before `CLLocation`
+  construction, preserving the existing nil-result behavior on rejection.
+- Added executable boundary, out-of-range, NaN, and infinity cases and static
+  contracts for the production policy, API ordering, tests, documentation, and
+  completed evidence.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- A pre-completion isolated snapshot passed `make check` from its repository
+  root and the absolute external-directory Make gate with
+  `SKIP_XCODE_BUILD=1`.
+- The finalized worktree passed all four repository-root Make gates and the
+  absolute external-directory Make gate with `SKIP_XCODE_BUILD=1`.
+- Eight isolated hostile mutations were rejected across both finiteness
+  clauses, latitude and longitude ranges, API delegation, an executable edge
+  case, changelog evidence, and plan completion.
+- Python syntax and `git diff --check` passed before final repository gates.
+- `swiftc`, CocoaPods, and Xcode are unavailable on this Linux host, so native
+  Swift compilation, simulator/device behavior, live ferry data, CoreLocation,
+  and UI test execution are not claimed.

--- a/docs/plans/2026-06-17-ferry-coordinate-domain-validation.md
+++ b/docs/plans/2026-06-17-ferry-coordinate-domain-validation.md
@@ -1,0 +1,92 @@
+---
+title: Reject invalid ferry coordinate domains
+type: reliability
+date: 2026-06-17
+status: in_progress
+execution: code
+---
+
+# Reject invalid ferry coordinate domains
+
+## Goal
+
+Prevent numeric but non-finite or out-of-range ferry coordinates from reaching
+`CLLocation` and MapKit while preserving the existing API, refresh, response
+revision, and map-publication behavior.
+
+## Requirements
+
+- Accept finite latitude values from -90 through 90 degrees inclusive.
+- Accept finite longitude values from -180 through 180 degrees inclusive.
+- Reject NaN, positive or negative infinity, and values outside either range.
+- Apply the guard after locale-independent numeric parsing and before creating
+  a `CLLocation`.
+- Keep the coordinate-domain decision in the existing pure app-target location
+  policy so it remains executable without UIKit, CoreLocation, Alamofire, or
+  live ferry data.
+- Add mutation-sensitive executable and static contracts for boundaries,
+  non-finite values, API integration, documentation, and completed evidence.
+
+## Key Technical Decisions
+
+- Extend `LocationResponsePolicy.swift` rather than adding another app source.
+  The file already belongs to the app target and its standalone runner, which
+  avoids unrelated Xcode project changes.
+- Validate parsed `Double` values directly. String parsing remains responsible
+  only for syntax and locale independence; the new policy owns geographic
+  domain validity.
+- Preserve the current nil-result contract. Invalid coordinates complete with
+  `nil`, leaving the last successfully published ferry annotation untouched.
+
+## Implementation Units
+
+### U1. Pure coordinate policy and executable cases
+
+**Files:** `Larkspur Ferry/LocationResponsePolicy.swift`,
+`Tests/LocationResponsePolicyTests/main.swift`
+
+Add the finite/range predicate and cases for normal coordinates, exact
+boundaries, each out-of-range direction, NaN, and both infinities.
+
+### U2. API integration
+
+**Files:** `Larkspur Ferry/API.swift`
+
+Require the parsed latitude and longitude to satisfy the pure policy before
+constructing `CLLocation`; otherwise complete with `nil` through the existing
+guard path.
+
+### U3. Maintained verification contract
+
+**Files:** `scripts/check-baseline.py`, `README.md`, `SECURITY.md`, `VISION.md`,
+`CHANGES.md`, and this plan
+
+Protect the policy expression, API ordering, executable cases, repository
+guidance, and truthful completed-plan evidence against isolated weakening.
+
+## Verification Strategy
+
+- Run the location policy harness when `swiftc` is available and the maintained
+  baseline on this host regardless of toolchain availability.
+- Run `make check` from the repository root and via the absolute Makefile from
+  an external directory with the documented Xcode skip.
+- Reject isolated mutations to finiteness, latitude bounds, longitude bounds,
+  API delegation, executable edge cases, documentation, and plan completion.
+- Audit the exact intended diff, Python syntax, generated artifacts, file modes,
+  conflict markers, and credential-like additions before commit.
+
+## Scope Boundaries
+
+- Do not change ferry endpoint construction, response validation, retry or
+  timeout behavior, timer cadence, response revisions, annotations, schedule
+  parsing, geocoding, dependencies, deployment targets, or UI tests.
+- Do not claim simulator, device, live ferry API, CoreLocation, or Xcode
+  execution from Linux.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-17-location-response-revision-policy.md
+++ b/docs/plans/2026-06-17-location-response-revision-policy.md
@@ -1,0 +1,117 @@
+---
+title: Reject stale ferry location responses
+type: reliability
+date: 2026-06-17
+status: completed
+execution: code
+---
+
+# Reject stale ferry location responses
+
+## Goal
+
+Prevent an older overlapping ferry-location callback from replacing a newer
+map position while preserving the existing visibility, timer, annotation, and
+network boundaries.
+
+## Requirements
+
+- Assign a monotonic revision to every location request issued by the map.
+- Publish a location only when its request revision still matches the latest
+  issued revision and the map remains visible.
+- Invalidate outstanding revisions when disappearance begins so callbacks from
+  a prior appearance fail closed.
+- Keep the acceptance decision in a pure app-target policy that can execute
+  without UIKit, CoreLocation, Alamofire, or live ferry data.
+- Preserve the 30-second refresh timer, weak callback ownership, main-thread UI
+  publication, existing annotation filtering, and nil-location behavior.
+- Add mutation-sensitive static contracts for policy behavior, controller
+  delegation, project membership, runner cleanup, Make wiring, and completed
+  plan evidence.
+
+## Key Technical Decisions
+
+- Reuse the existing schedule-response policy shape: a small production Swift
+  function plus a standalone executable harness when `swiftc` is available.
+- Increment the location revision before each API request and again when the
+  map disappears. This rejects both out-of-order overlapping responses and
+  callbacks owned by a previous appearance without changing the API client.
+- Keep visibility in the controller guard because it is UIKit lifecycle state;
+  the pure policy owns only revision equality.
+
+## Implementation Units
+
+### U1. Location response policy
+
+**Files:** `Larkspur Ferry/LocationResponsePolicy.swift`,
+`Tests/LocationResponsePolicyTests/main.swift`
+
+Add a pure revision-equality policy and executable cases for current, older,
+newer, zero, and disappearance-invalidated revisions.
+
+### U2. Map lifecycle integration
+
+**Files:** `Larkspur Ferry/MapViewController.swift`,
+`Larkspur Ferry.xcodeproj/project.pbxproj`
+
+Issue and capture a revision for each request, invalidate it during
+`viewWillDisappear`, and require both current revision and visibility before
+publishing map state.
+
+### U3. Maintained verification contract
+
+**Files:** `Makefile`, `scripts/check-baseline.py`,
+`scripts/run-location-response-policy-tests.sh`, `README.md`, `SECURITY.md`,
+`VISION.md`, `CHANGES.md`, and this plan
+
+Run the policy harness from every Make gate when `swiftc` is available, retain
+truthful skips on this Linux host, and protect the source, test, project,
+runner, documentation, and completed-plan evidence against weakening.
+
+## Verification Strategy
+
+- Run all four Make aliases from the repository root and the absolute Makefile
+  gate from `/tmp` with the explicit legacy-Xcode skip.
+- Exercise runner success, compiler failure, signal cleanup, and temporary
+  binary cleanup without requiring Xcode or live ferry data.
+- Reject isolated mutations to revision equality, controller capture and
+  invalidation, project membership, executable cases, Make wiring, runner
+  cleanup, documentation, and plan status.
+- Audit the exact intended diff, shell and Python syntax, generated artifacts,
+  file modes, conflict markers, and credential-like additions before commit.
+
+## Scope Boundaries
+
+- Do not change ferry API requests, retry behavior, timer cadence, map styling,
+  schedule or geocode policies, CocoaPods, deployment targets, or the legacy UI
+  test target.
+- Do not claim simulator, device, live ferry API, CoreLocation, or Xcode
+  execution from Linux.
+
+## Work Completed
+
+- Added a pure location-response revision policy to the app target and a
+  standalone five-case executable harness.
+- Assigned and captured a monotonic revision for every map-location request,
+  invalidated ownership during disappearance, and required current revision
+  plus visibility before map publication.
+- Extended every Make alias, the maintained baseline, project metadata, and
+  repository guidance with the new response-ownership contract.
+
+## Verification Completed
+
+- All four Make gates passed from the repository root with the unavailable
+  `swiftc` and Xcode boundaries reported truthfully.
+- The external absolute Makefile gate passed from `/tmp` with
+  `SKIP_XCODE_BUILD=1`.
+- Controlled fake-compiler probes proved successful execution, exit-7 compiler
+  failure propagation, signal-143 handling, and temporary-build cleanup.
+- Nine isolated hostile mutations were rejected across revision equality,
+  controller delegation, disappearance invalidation, project membership,
+  executable cases, runner cleanup, Make wiring, documentation, and
+  completed-plan evidence.
+- Shell and Python syntax, exact diff, generated-artifact, file-mode,
+  conflict-marker, and changed-line credential-pattern audits passed.
+- `swiftc`, CocoaPods, and Xcode are unavailable on this Linux host, so native
+  Swift compilation, simulator/device behavior, live ferry data, and UI test
+  execution were not claimed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -14,12 +14,18 @@ PLAN = ROOT / "docs/plans/2026-06-08-larkspur-ferry-baseline.md"
 MAIN_THREAD_PLAN = ROOT / "docs/plans/2026-06-09-main-thread-ui-updates.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 EXPECTED_MAKEFILE = """ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SWIFTC ?= swiftc
 
 .PHONY: build check lint test
 
 lint test build: check
 
 check:
+\t@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \\
+\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \\
+\telse \\
+\t\techo "swiftc unavailable; executable schedule response tests skipped"; \\
+\tfi
 \tpython3 "$(ROOT)/scripts/check-baseline.py"
 \tcd "$(ROOT)" && ./build.sh
 """
@@ -113,6 +119,7 @@ def main():
         "docs/plans/2026-06-14-empty-location-update-stop.md",
         "docs/plans/2026-06-14-location-direction-alignment.md",
         "docs/plans/2026-06-15-stale-geocode-direction-guard.md",
+        "docs/plans/2026-06-16-schedule-response-revision-policy.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -123,6 +130,7 @@ def main():
         "Larkspur Ferry/Info.plist",
         "Larkspur Ferry/API.swift",
         "Larkspur Ferry/Extensions.swift",
+        "Larkspur Ferry/ScheduleResponsePolicy.swift",
         "Larkspur Ferry/ViewController.swift",
         "Larkspur Ferry/MapViewController.swift",
         "Larkspur Ferry/PinAnnotation.swift",
@@ -133,6 +141,8 @@ def main():
         "Larkspur FerryUITests/Info.plist",
         "Larkspur FerryUITests/Larkspur_FerryUITests.swift",
         "Larkspur FerryUITests/SnapshotHelper.swift",
+        "Tests/ScheduleResponsePolicyTests/main.swift",
+        "scripts/run-schedule-response-policy-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -171,7 +181,10 @@ def main():
     build_script = read("build.sh")
     api = read("Larkspur Ferry/API.swift")
     extensions = read("Larkspur Ferry/Extensions.swift")
+    schedule_response_policy = read("Larkspur Ferry/ScheduleResponsePolicy.swift")
     view_controller = read("Larkspur Ferry/ViewController.swift")
+    schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
+    schedule_response_runner = read("scripts/run-schedule-response-policy-tests.sh")
     map_controller = read("Larkspur Ferry/MapViewController.swift")
     pin_annotation = read("Larkspur Ferry/PinAnnotation.swift")
     app_swift = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
@@ -202,6 +215,7 @@ def main():
     visible_map_plan = read("docs/plans/2026-06-14-visible-map-response-publication.md")
     empty_location_plan = read("docs/plans/2026-06-14-empty-location-update-stop.md")
     stale_geocode_plan = read("docs/plans/2026-06-15-stale-geocode-direction-guard.md")
+    schedule_response_plan = read("docs/plans/2026-06-16-schedule-response-revision-policy.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -209,6 +223,16 @@ def main():
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
             f"build.sh must pass POSIX shell syntax checks: {shell_result.stderr.strip()}",
+            failures)
+    runner_shell_result = subprocess.run(
+        ["sh", "-n", "scripts/run-schedule-response-policy-tests.sh"],
+        cwd=str(ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    require(runner_shell_result.returncode == 0,
+            "schedule response runner must pass POSIX shell syntax checks: " + runner_shell_result.stderr.strip(),
             failures)
     require("function ci_build" not in build_script and "ci_build() {" in build_script and "ci_test() {" in build_script,
             "build.sh must use POSIX-compatible shell function syntax",
@@ -234,6 +258,10 @@ def main():
             failures)
     require("CoreLocation.framework" in project and "Pods_Larkspur_Ferry.framework" in project,
             "Xcode project must keep CoreLocation and CocoaPods framework references",
+            failures)
+    require(project.count("/* ScheduleResponsePolicy.swift */") == 3 and
+            project.count("/* ScheduleResponsePolicy.swift in Sources */") == 2,
+            "ScheduleResponsePolicy.swift must remain a unique app-target source",
             failures)
     require("Alamofire', '~> 4.0'" in podfile and "Alamofire (4.3.0)" in podlock,
             "Podfile and lockfile must preserve the pinned Alamofire baseline",
@@ -277,12 +305,43 @@ def main():
             "table rendering must guard indexes, cell casts, and invalid ferry times",
             failures)
     require("let requestedFrom = f" in view_controller and
+            "let requestedDirectionRevision = directionRevision" in view_controller and
             "API.sharedInstance.getTimes(from: requestedFrom) { [weak self]" in view_controller and
             "DispatchQueue.main.async" in view_controller and
             "guard let viewController = self," in view_controller and
-            "viewController.f == requestedFrom else" in view_controller and
+            "acceptsFerryScheduleResponse(" in view_controller and
+            "true || acceptsFerryScheduleResponse(" not in view_controller and
+            "requestedDirectionRevision: requestedDirectionRevision" in view_controller and
+            "currentDirectionRevision: viewController.directionRevision" in view_controller and
             "viewController.tableView.reloadData()" in view_controller,
-            "schedule API callback must reject stale directions and update table state on the main queue without retaining the view controller",
+            "schedule API callback must reject stale direction revisions and update table state on the main queue without retaining the view controller",
+            failures)
+    require('requestedFrom == "Larkspur" || requestedFrom == "San Francisco"' in schedule_response_policy and
+            "requestedFrom == currentFrom" in schedule_response_policy and
+            "requestedDirectionRevision == currentDirectionRevision" in schedule_response_policy,
+            "production schedule response policy must require a known matching origin and revision",
+            failures)
+    runner_contract = (
+        "Larkspur Ferry/ScheduleResponsePolicy.swift",
+        "Tests/ScheduleResponsePolicyTests/main.swift",
+        'mktemp -d "${TMPDIR:-/tmp}/larkspur-schedule-response-tests.XXXXXX"',
+        "trap cleanup 0",
+    )
+    require(all(schedule_response_runner.count(fragment) == 1 for fragment in runner_contract),
+            "schedule response runner must compile production policy with bounded cleanup",
+            failures)
+    test_contract = (
+        'true, "initial Larkspur response"',
+        'true, "current San Francisco response"',
+        'false, "changed origin"',
+        'false, "reverse changed origin"',
+        'false, "tap-away-and-back stale response"',
+        'false, "newer same-origin request"',
+        'false, "empty origin"',
+        'false, "unknown origin"',
+    )
+    require(all(schedule_response_tests.count(fragment) == 1 for fragment in test_contract),
+            "executable schedule response tests must preserve all eight behavioral cases",
             failures)
     require('dateFormatter.locale = Locale(identifier: "en_US_POSIX")' in view_controller,
             "schedule time parsing must use a POSIX locale for fixed-format API times",
@@ -480,6 +539,23 @@ def main():
             "stale geocoder completion" in changes.lower(),
             "project guidance must document stale geocoder completion rejection",
             failures)
+    require("revision-aware schedule response" in readme.lower() and
+            "revision-aware schedule response" in vision.lower() and
+            "revision-aware schedule response" in security.lower() and
+            "revision-aware schedule response" in changes.lower(),
+            "project guidance must document revision-aware schedule response rejection",
+            failures)
+    verification = schedule_response_plan.split("## Verification Completed", 1)[-1]
+    normalized_verification = " ".join(verification.lower().split())
+    require("status: completed" in schedule_response_plan and
+            "## Verification Completed" in schedule_response_plan and
+            "all four make gates passed" in normalized_verification and
+            "external absolute makefile gate passed" in normalized_verification and
+            "eight hostile mutations were rejected" in normalized_verification and
+            "hosted pull-request check" in normalized_verification and
+            not re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE),
+            "schedule response revision plan must retain completed verification evidence",
+            failures)
     require("Alamofire" in overview and "MapKit" in overview and "Integrations: Twitter" not in overview,
             "overview SVG must name the real app integrations",
             failures)
@@ -616,7 +692,7 @@ def main():
             'SKIP_XCODE_BUILD: "1"' in workflow and
             "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow and
             "run: make check" in workflow,
-            "Check workflow must use one pinned credential-free checkout and stay read-only, bounded, and structural-only",
+            "Check workflow must use one pinned credential-free checkout and stay read-only and bounded",
             failures)
     guidance = " ".join("\n".join([read("README.md"), read("SECURITY.md"), read("VISION.md"), read("CHANGES.md")]).split()).lower()
     require("checkout credentials are not persisted" in guidance and "credential-free checkout" in guidance,

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -329,7 +329,17 @@ def main():
     require("guard indexPath.row < self.items.count" in view_controller and "date.map" in view_controller,
             "table rendering must guard indexes, cell casts, and invalid ferry times",
             failures)
-    require("let requestedFrom = f" in view_controller and
+    schedule_request_start = view_controller.find("func getBoats()")
+    schedule_request_increment = view_controller.find("scheduleRequestRevision += 1", schedule_request_start)
+    schedule_origin_capture = view_controller.find("let requestedFrom = f", schedule_request_increment)
+    schedule_direction_capture = view_controller.find("let requestedDirectionRevision = directionRevision", schedule_origin_capture)
+    schedule_request_capture = view_controller.find("let requestedScheduleRequestRevision = scheduleRequestRevision", schedule_direction_capture)
+    schedule_api_call = view_controller.find("API.sharedInstance.getTimes(from: requestedFrom) { [weak self]", schedule_request_capture)
+    require("var scheduleRequestRevision = 0" in view_controller and
+            -1 not in (schedule_request_start, schedule_request_increment, schedule_origin_capture,
+                       schedule_direction_capture, schedule_request_capture, schedule_api_call) and
+            schedule_request_start < schedule_request_increment < schedule_origin_capture <
+            schedule_direction_capture < schedule_request_capture < schedule_api_call and
             "let requestedDirectionRevision = directionRevision" in view_controller and
             "API.sharedInstance.getTimes(from: requestedFrom) { [weak self]" in view_controller and
             "DispatchQueue.main.async" in view_controller and
@@ -337,14 +347,17 @@ def main():
             "acceptsFerryScheduleResponse(" in view_controller and
             "true || acceptsFerryScheduleResponse(" not in view_controller and
             "requestedDirectionRevision: requestedDirectionRevision" in view_controller and
+            "requestedScheduleRequestRevision: requestedScheduleRequestRevision" in view_controller and
             "currentDirectionRevision: viewController.directionRevision" in view_controller and
+            "currentScheduleRequestRevision: viewController.scheduleRequestRevision" in view_controller and
             "viewController.tableView.reloadData()" in view_controller,
-            "schedule API callback must reject stale direction revisions and update table state on the main queue without retaining the view controller",
+            "schedule API callback must reject stale direction and request revisions and update table state on the main queue without retaining the view controller",
             failures)
     require('requestedFrom == "Larkspur" || requestedFrom == "San Francisco"' in schedule_response_policy and
             "requestedFrom == currentFrom" in schedule_response_policy and
-            "requestedDirectionRevision == currentDirectionRevision" in schedule_response_policy,
-            "production schedule response policy must require a known matching origin and revision",
+            "requestedDirectionRevision == currentDirectionRevision" in schedule_response_policy and
+            "requestedScheduleRequestRevision == currentScheduleRequestRevision" in schedule_response_policy,
+            "production schedule response policy must require a known matching origin, direction revision, and request revision",
             failures)
     runner_contract = (
         "Larkspur Ferry/ScheduleResponsePolicy.swift",
@@ -361,12 +374,13 @@ def main():
         'false, "changed origin"',
         'false, "reverse changed origin"',
         'false, "tap-away-and-back stale response"',
-        'false, "newer same-origin request"',
+        'false, "newer same-origin direction request"',
+        'false, "newer same-origin schedule request"',
         'false, "empty origin"',
         'false, "unknown origin"',
     )
     require(all(schedule_response_tests.count(fragment) == 1 for fragment in test_contract),
-            "executable schedule response tests must preserve all eight behavioral cases",
+            "executable schedule response tests must preserve all nine behavioral cases",
             failures)
     require("requestedRevision == currentRevision" in location_response_policy,
             "production location response policy must require the current request revision",
@@ -646,7 +660,7 @@ def main():
             "## Verification Completed" in schedule_response_plan and
             "all four make gates passed" in normalized_verification and
             "external absolute makefile gate passed" in normalized_verification and
-            "eight hostile mutations were rejected" in normalized_verification and
+            "nine hostile mutations were rejected" in normalized_verification and
             "hosted pull-request check" in normalized_verification and
             not re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE),
             "schedule response revision plan must retain completed verification evidence",
@@ -801,8 +815,10 @@ def main():
             failures)
     require(checkout_step is not None and
             actions == ["actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"] and
+            workflow.count("permissions:") == 1 and
             workflow.count("persist-credentials:") == 1 and
             "persist-credentials: true" not in workflow and
+            re.search(r"(?m)^\s+[A-Za-z-]+:\s+write\s*$", workflow) is None and
             "permissions:\n  contents: read" in workflow and "cancel-in-progress: true" in workflow and
             "runs-on: macos-15" in workflow and "timeout-minutes: 10" in workflow and
             'SKIP_XCODE_BUILD: "1"' in workflow and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,8 +23,9 @@ lint test build: check
 check:
 \t@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \\
 \t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \\
+\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \\
 \telse \\
-\t\techo "swiftc unavailable; executable schedule response tests skipped"; \\
+\t\techo "swiftc unavailable; executable response policy tests skipped"; \\
 \tfi
 \tpython3 "$(ROOT)/scripts/check-baseline.py"
 \tcd "$(ROOT)" && ./build.sh
@@ -120,6 +121,7 @@ def main():
         "docs/plans/2026-06-14-location-direction-alignment.md",
         "docs/plans/2026-06-15-stale-geocode-direction-guard.md",
         "docs/plans/2026-06-16-schedule-response-revision-policy.md",
+        "docs/plans/2026-06-17-location-response-revision-policy.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -131,6 +133,7 @@ def main():
         "Larkspur Ferry/API.swift",
         "Larkspur Ferry/Extensions.swift",
         "Larkspur Ferry/ScheduleResponsePolicy.swift",
+        "Larkspur Ferry/LocationResponsePolicy.swift",
         "Larkspur Ferry/ViewController.swift",
         "Larkspur Ferry/MapViewController.swift",
         "Larkspur Ferry/PinAnnotation.swift",
@@ -142,7 +145,9 @@ def main():
         "Larkspur FerryUITests/Larkspur_FerryUITests.swift",
         "Larkspur FerryUITests/SnapshotHelper.swift",
         "Tests/ScheduleResponsePolicyTests/main.swift",
+        "Tests/LocationResponsePolicyTests/main.swift",
         "scripts/run-schedule-response-policy-tests.sh",
+        "scripts/run-location-response-policy-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -182,9 +187,12 @@ def main():
     api = read("Larkspur Ferry/API.swift")
     extensions = read("Larkspur Ferry/Extensions.swift")
     schedule_response_policy = read("Larkspur Ferry/ScheduleResponsePolicy.swift")
+    location_response_policy = read("Larkspur Ferry/LocationResponsePolicy.swift")
     view_controller = read("Larkspur Ferry/ViewController.swift")
     schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
+    location_response_tests = read("Tests/LocationResponsePolicyTests/main.swift")
     schedule_response_runner = read("scripts/run-schedule-response-policy-tests.sh")
+    location_response_runner = read("scripts/run-location-response-policy-tests.sh")
     map_controller = read("Larkspur Ferry/MapViewController.swift")
     pin_annotation = read("Larkspur Ferry/PinAnnotation.swift")
     app_swift = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
@@ -216,6 +224,7 @@ def main():
     empty_location_plan = read("docs/plans/2026-06-14-empty-location-update-stop.md")
     stale_geocode_plan = read("docs/plans/2026-06-15-stale-geocode-direction-guard.md")
     schedule_response_plan = read("docs/plans/2026-06-16-schedule-response-revision-policy.md")
+    location_response_plan = read("docs/plans/2026-06-17-location-response-revision-policy.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -233,6 +242,16 @@ def main():
     )
     require(runner_shell_result.returncode == 0,
             "schedule response runner must pass POSIX shell syntax checks: " + runner_shell_result.stderr.strip(),
+            failures)
+    location_runner_shell_result = subprocess.run(
+        ["sh", "-n", "scripts/run-location-response-policy-tests.sh"],
+        cwd=str(ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    require(location_runner_shell_result.returncode == 0,
+            "location response runner must pass POSIX shell syntax checks: " + location_runner_shell_result.stderr.strip(),
             failures)
     require("function ci_build" not in build_script and "ci_build() {" in build_script and "ci_test() {" in build_script,
             "build.sh must use POSIX-compatible shell function syntax",
@@ -262,6 +281,10 @@ def main():
     require(project.count("/* ScheduleResponsePolicy.swift */") == 3 and
             project.count("/* ScheduleResponsePolicy.swift in Sources */") == 2,
             "ScheduleResponsePolicy.swift must remain a unique app-target source",
+            failures)
+    require(project.count("/* LocationResponsePolicy.swift */") == 3 and
+            project.count("/* LocationResponsePolicy.swift in Sources */") == 2,
+            "LocationResponsePolicy.swift must remain a unique app-target source",
             failures)
     require("Alamofire', '~> 4.0'" in podfile and "Alamofire (4.3.0)" in podlock,
             "Podfile and lockfile must preserve the pinned Alamofire baseline",
@@ -343,6 +366,28 @@ def main():
     require(all(schedule_response_tests.count(fragment) == 1 for fragment in test_contract),
             "executable schedule response tests must preserve all eight behavioral cases",
             failures)
+    require("requestedRevision == currentRevision" in location_response_policy,
+            "production location response policy must require the current request revision",
+            failures)
+    location_runner_contract = (
+        "Larkspur Ferry/LocationResponsePolicy.swift",
+        "Tests/LocationResponsePolicyTests/main.swift",
+        'mktemp -d "${TMPDIR:-/tmp}/larkspur-location-response-tests.XXXXXX"',
+        "trap cleanup 0",
+    )
+    require(all(location_response_runner.count(fragment) == 1 for fragment in location_runner_contract),
+            "location response runner must compile production policy with bounded cleanup",
+            failures)
+    location_test_contract = (
+        'true, "initial request"',
+        'true, "latest request"',
+        'false, "older overlapping request"',
+        'false, "noncurrent future request"',
+        'false, "disappearance invalidation"',
+    )
+    require(all(location_response_tests.count(fragment) == 1 for fragment in location_test_contract),
+            "executable location response tests must preserve all five revision cases",
+            failures)
     require('dateFormatter.locale = Locale(identifier: "en_US_POSIX")' in view_controller,
             "schedule time parsing must use a POSIX locale for fixed-format API times",
             failures)
@@ -416,22 +461,36 @@ def main():
     require("API.sharedInstance.getLocation(completion: { [weak self]" in map_controller and
             "DispatchQueue.main.async" in map_controller and
             "guard let viewController = self," in map_controller and
-            "viewController.isMapVisible else" in map_controller and
+            "viewController.isMapVisible," in map_controller and
+            "acceptsFerryLocationResponse(" in map_controller and
+            "requestedRevision: requestedLocationRevision" in map_controller and
+            "currentRevision: viewController.locationRequestRevision" in map_controller and
             "viewController.mapView.addAnnotation(info1)" in map_controller,
-            "map API callback must update a visible map on the main queue without retaining the view controller",
+            "map API callback must publish only the current visible response on the main queue without retaining the view controller",
             failures)
     appear_index = map_controller.find("isMapVisible = true")
     start_index = map_controller.find("startLocationRefreshTimer()", appear_index)
     disappear_index = map_controller.find("isMapVisible = false")
     invalidate_index = map_controller.find("locationRefreshTimer?.invalidate()", disappear_index)
-    visibility_guard_index = map_controller.find("viewController.isMapVisible else")
+    visibility_guard_index = map_controller.find("viewController.isMapVisible,")
+    revision_guard_index = map_controller.find("acceptsFerryLocationResponse(", visibility_guard_index)
     annotation_index = map_controller.find("viewController.removeExistingFerryAnnotations()", visibility_guard_index)
+    request_start = map_controller.find("func getLocation()")
+    request_increment = map_controller.find("locationRequestRevision += 1", request_start)
+    request_capture = map_controller.find("let requestedLocationRevision = locationRequestRevision", request_increment)
+    request_call = map_controller.find("API.sharedInstance.getLocation", request_capture)
+    disappearance_revision = map_controller.find("locationRequestRevision += 1", disappear_index)
     require("var isMapVisible = false" in map_controller and
+            "var locationRequestRevision = 0" in map_controller and
             -1 not in (appear_index, start_index, disappear_index, invalidate_index,
-                       visibility_guard_index, annotation_index) and
+                       visibility_guard_index, revision_guard_index, annotation_index,
+                       request_start, request_increment, request_capture, request_call,
+                       disappearance_revision) and
             appear_index < start_index and disappear_index < invalidate_index and
-            visibility_guard_index < annotation_index,
-            "map visibility must bracket refresh work and guard response publication before UI mutation",
+            disappear_index < disappearance_revision < invalidate_index and
+            request_increment < request_capture < request_call and
+            visibility_guard_index < revision_guard_index < annotation_index,
+            "map visibility and request revisions must bracket refresh work before UI mutation",
             failures)
     require("func removeExistingFerryAnnotations()" in map_controller and
             "filter { $0 is CustomPointAnnotation }" in map_controller and
@@ -441,7 +500,8 @@ def main():
     require(map_controller.count("removeExistingFerryAnnotations()") >= 2 and "if self.mapView.annotations.count == 1" not in map_controller,
             "map flow must refresh ferry annotations without relying on the total annotation count",
             failures)
-    require("func getLocation() {\n        API.sharedInstance.getLocation" in map_controller and
+    require("func getLocation() {" in map_controller and
+            "API.sharedInstance.getLocation" in map_controller and
             "viewController.removeExistingFerryAnnotations()" in map_controller,
             "map flow must preserve the last ferry annotation until a successful refresh replaces it",
             failures)
@@ -545,6 +605,12 @@ def main():
             "revision-aware schedule response" in changes.lower(),
             "project guidance must document revision-aware schedule response rejection",
             failures)
+    require("revision-aware ferry-location" in readme.lower() and
+            "revision-aware ferry-location" in vision.lower() and
+            "revision-aware ferry-location" in security.lower() and
+            "revision-aware ferry-location" in changes.lower(),
+            "project guidance must document revision-aware ferry-location response rejection",
+            failures)
     verification = schedule_response_plan.split("## Verification Completed", 1)[-1]
     normalized_verification = " ".join(verification.lower().split())
     require("status: completed" in schedule_response_plan and
@@ -555,6 +621,18 @@ def main():
             "hosted pull-request check" in normalized_verification and
             not re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE),
             "schedule response revision plan must retain completed verification evidence",
+            failures)
+    location_verification = location_response_plan.split("## Verification Completed", 1)[-1]
+    normalized_location_verification = " ".join(location_verification.lower().split())
+    require("status: completed" in location_response_plan and
+            "## Work Completed" in location_response_plan and
+            "## Verification Completed" in location_response_plan and
+            "all four make gates passed" in normalized_location_verification and
+            "external absolute makefile gate passed" in normalized_location_verification and
+            "nine isolated hostile mutations were rejected" in normalized_location_verification and
+            "signal-143 handling" in normalized_location_verification and
+            not re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", location_verification, re.IGNORECASE),
+            "location response revision plan must retain completed verification evidence",
             failures)
     require("Alamofire" in overview and "MapKit" in overview and "Integrations: Twitter" not in overview,
             "overview SVG must name the real app integrations",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -122,6 +122,7 @@ def main():
         "docs/plans/2026-06-15-stale-geocode-direction-guard.md",
         "docs/plans/2026-06-16-schedule-response-revision-policy.md",
         "docs/plans/2026-06-17-location-response-revision-policy.md",
+        "docs/plans/2026-06-17-ferry-coordinate-domain-validation.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -225,6 +226,7 @@ def main():
     stale_geocode_plan = read("docs/plans/2026-06-15-stale-geocode-direction-guard.md")
     schedule_response_plan = read("docs/plans/2026-06-16-schedule-response-revision-policy.md")
     location_response_plan = read("docs/plans/2026-06-17-location-response-revision-policy.md")
+    coordinate_domain_plan = read("docs/plans/2026-06-17-ferry-coordinate-domain-validation.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -369,6 +371,17 @@ def main():
     require("requestedRevision == currentRevision" in location_response_policy,
             "production location response policy must require the current request revision",
             failures)
+    require("latitude.isFinite && longitude.isFinite" in location_response_policy and
+            "(-90.0...90.0).contains(latitude)" in location_response_policy and
+            "(-180.0...180.0).contains(longitude)" in location_response_policy,
+            "production location policy must reject non-finite and out-of-range coordinates",
+            failures)
+    coordinate_guard_index = api.find("isValidFerryCoordinate(latitude: lat, longitude: lng)")
+    location_creation_index = api.find("CLLocation(latitude: lat, longitude: lng)")
+    require(coordinate_guard_index != -1 and location_creation_index != -1 and
+            coordinate_guard_index < location_creation_index,
+            "ferry API must validate parsed coordinates before CLLocation creation",
+            failures)
     location_runner_contract = (
         "Larkspur Ferry/LocationResponsePolicy.swift",
         "Tests/LocationResponsePolicyTests/main.swift",
@@ -387,6 +400,22 @@ def main():
     )
     require(all(location_response_tests.count(fragment) == 1 for fragment in location_test_contract),
             "executable location response tests must preserve all five revision cases",
+            failures)
+    coordinate_test_contract = (
+        'true, "normal ferry coordinate"',
+        'true, "minimum coordinate boundaries"',
+        'true, "maximum coordinate boundaries"',
+        'false, "latitude below minimum"',
+        'false, "latitude above maximum"',
+        'false, "longitude below minimum"',
+        'false, "longitude above maximum"',
+        'false, "NaN latitude"',
+        'false, "NaN longitude"',
+        'false, "infinite latitude"',
+        'false, "infinite longitude"',
+    )
+    require(all(location_response_tests.count(fragment) == 1 for fragment in coordinate_test_contract),
+            "executable location response tests must preserve all coordinate domain cases",
             failures)
     require('dateFormatter.locale = Locale(identifier: "en_US_POSIX")' in view_controller,
             "schedule time parsing must use a POSIX locale for fixed-format API times",
@@ -656,6 +685,9 @@ def main():
     require("locale-independent coordinate parsing" in changes.lower(),
             "CHANGES must record locale-independent coordinate parsing",
             failures)
+    require("finite coordinate domain validation" in changes.lower(),
+            "CHANGES must record finite coordinate domain validation",
+            failures)
     require("posix schedule time parsing" in changes.lower(),
             "CHANGES must record POSIX schedule time parsing",
             failures)
@@ -740,6 +772,12 @@ def main():
             "Eight isolated hostile mutations" in stale_geocode_plan and
             "git diff --check" in stale_geocode_plan,
             "stale geocode direction plan must record completed gate and mutation verification",
+            failures)
+    require("status: completed" in coordinate_domain_plan and
+            "Verification Completed" in coordinate_domain_plan and
+            "isolated hostile mutations" in coordinate_domain_plan.lower() and
+            "external" in coordinate_domain_plan.lower(),
+            "coordinate domain validation plan must record completed verification",
             failures)
     require("in-flight map response" in readme.lower() and
             "in-flight ferry location responses" in changes.lower(),

--- a/scripts/run-location-response-policy-tests.sh
+++ b/scripts/run-location-response-policy-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/larkspur-location-response-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/Larkspur Ferry/LocationResponsePolicy.swift" \
+    "$ROOT/Tests/LocationResponsePolicyTests/main.swift" \
+    -o "$BUILD_DIR/location-response-policy-tests"
+
+"$BUILD_DIR/location-response-policy-tests"

--- a/scripts/run-schedule-response-policy-tests.sh
+++ b/scripts/run-schedule-response-policy-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/larkspur-schedule-response-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/Larkspur Ferry/ScheduleResponsePolicy.swift" \
+    "$ROOT/Tests/ScheduleResponsePolicyTests/main.swift" \
+    -o "$BUILD_DIR/schedule-response-policy-tests"
+
+"$BUILD_DIR/schedule-response-policy-tests"


### PR DESCRIPTION
## Summary

- require both ferry origin and direction revision to match before publishing a schedule callback
- reject tap-away-and-back responses from an older revision through a pure production policy
- compile and execute that policy through an eight-case Swift harness on hosted macOS

## Baseline

A schedule response could remain eligible after the user changed ferry direction and later returned to the same origin, because publication authority did not require the current direction revision as well as the origin revision.

## Improvements

- centralize schedule publication authority in a pure production revision policy
- require both origin and direction revisions to match the active request
- execute the policy through a deterministic eight-case Swift harness in hosted macOS validation

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- external absolute-Makefile `make check`
- fake-compiler success, exit-7 failure, signal-143 cleanup, and temporary-directory cleanup probes
- eight hostile mutations rejected
- staged diff, generated-artifact, executable-mode, and changed-line credential audits
- exact-head push and pull-request baseline checks succeeded

## Risk

Local Linux validation truthfully skipped Swift and Xcode execution because those tools are unavailable. The canonical hosted checks are the executable authority. The legacy live-data UI test target remains non-deterministic and uninvoked, and PR #14 remains stacked on PR #13.

## Follow-Ups

- introduce deterministic schedule and location fixtures before enabling the legacy UI test target
- modernize the UI target and simulator selection in a dedicated change
- preserve base-first stack order; do not merge or close this PR without explicit authorization

