### PR TITLE
fix: protect derived Make root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = ROOT / "docs/plans/2026-06-08-larkspur-ferry-baseline.md"
 MAIN_THREAD_PLAN = ROOT / "docs/plans/2026-06-09-main-thread-ui-updates.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
-EXPECTED_MAKEFILE = """ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+EXPECTED_MAKEFILE = """override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: protect derived Make root

### Original Description

### Summary

Canonical Larkspur Ferry verification could be redirected outside the checkout by passing a command-line `ROOT` value to Make. The repository-derived root now remains authoritative, and the exact Makefile baseline rejects a downgrade to an overridable assignment.

## Testing

- Ran `lint`, `test`, `build`, and `check` from the repository with a hostile `ROOT` value.
- Ran the same four aliases from an external directory through the absolute Makefile path with a hostile `ROOT` value.
- All eight aliases passed the static baseline; Linux truthfully skipped executable Swift policy tests and the obsolete CocoaPods/Xcode build because those tools are unavailable.
- Confirmed a mutation back to ordinary `ROOT :=` fails the exact Makefile contract.
- Passed Python in-memory compilation, shell syntax, `git diff --check`, and `git fsck --strict`.
- Checksum-verified Gitleaks 8.30.1 found no secrets in 74 commits or the current tree.

## Post-Deploy Monitoring & Validation

No additional runtime monitoring is required because this changes only repository verification path resolution. During the first post-merge workflow window, the repository maintainer should confirm the `Check` baseline and CodeQL jobs remain successful for the merged `master` head; search GitHub Actions for `branch:master conclusion:failure`. Any failed baseline, redirected path, or missing-check signal should trigger reverting this commit and rerunning exact-head validation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the ferry app correctness, API safety, location handling, CI, testing, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted evidence is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, signing setting, API call, location behavior, workflow, or runtime behavior.

## Follow-Ups

No additional follow-up is introduced by this metadata-only update.
