### PR TITLE
fix: support spaced absolute Makefile paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Made absolute external Makefile invocations work when checkout paths contain
+  spaces or a literal apostrophe while rejecting `ROOT` and `MAKEFILE_LIST`
+  attempts to redirect verification.
+
 ## 2026-06-17
 
 - Added a revision-aware ferry-location response policy so an older overlapping

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$${path\# }; dirname -- "$$path")
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   guardrails, project metadata, and documentation contracts.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
-  `make -f /path/to/Larkspur-Ferry/Makefile check`.
+  `make -f /path/to/Larkspur-Ferry/Makefile check`. This remains supported when
+  checkout paths contain spaces or a literal apostrophe. `ROOT` and
+  `MAKEFILE_LIST` overrides cannot redirect verification into another tree.
 - The `lint`, `test`, and `build` targets intentionally alias the existing
   check path so the standard local gate commands stay available while preserving
   the guarded CocoaPods/Xcode skip behavior on hosts without that toolchain.

--- a/docs/plans/2026-06-21-spaced-makefile-path.md
+++ b/docs/plans/2026-06-21-spaced-makefile-path.md
@@ -1,0 +1,27 @@
+# Spaced Makefile Path
+
+status: completed
+
+## Problem
+
+GNU Make list functions split `MAKEFILE_LIST` on whitespace. The documented
+absolute `make -f` invocation therefore failed when the checkout path contained
+spaces, even though ordinary external-directory paths passed.
+
+## Change
+
+1. Derive the repository root from the raw Makefile path with shell-safe
+   single-quote escaping.
+2. Reject command-line and `-e` environment attempts to replace GNU Make's
+   automatic `MAKEFILE_LIST` value.
+3. Keep `override ROOT` so callers cannot redirect the gate.
+4. Exercise all four aliases from an unrelated directory with a checkout path
+   containing spaces, brackets, and a literal apostrophe.
+
+## Verification
+
+- Root and external `check`, `lint`, `test`, and `build` aliases passed.
+- Command-line and environment `ROOT` attacks stayed rooted in the checkout.
+- Command-line and environment `MAKEFILE_LIST` attacks failed closed.
+- Linux truthfully skipped Swift, CocoaPods, and Xcode execution while the
+  static ferry baseline and guarded build path passed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import json
+import os
 import plistlib
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import xml.etree.ElementTree as ET
 
 
@@ -13,7 +15,10 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = ROOT / "docs/plans/2026-06-08-larkspur-ferry-baseline.md"
 MAIN_THREAD_PLAN = ROOT / "docs/plans/2026-06-09-main-thread-ui-updates.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
-EXPECTED_MAKEFILE = """override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+EXPECTED_MAKEFILE = """ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$${path\\# }; dirname -- "$$path")
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test
@@ -87,6 +92,59 @@ def git_ls_files():
     return set(result.stdout.splitlines())
 
 
+def check_makefile_path_resolution(makefile, failures):
+    if not shutil.which("make"):
+        failures.append("make must be available to verify location-independent gates")
+        return
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        temporary_root = Path(temporary_directory)
+        checkout = temporary_root / "checkout with spaces 'quoted' [hostile]"
+        external = temporary_root / "external caller"
+        checkout.mkdir()
+        external.mkdir()
+        (checkout / "Makefile").write_text(makefile, encoding="utf-8")
+
+        for target in ("check", "lint", "test", "build"):
+            for extra_arguments in ((), ("ROOT=/tmp/untrusted",), ("-e", "ROOT=/tmp/untrusted")):
+                result = subprocess.run(
+                    ["make", "--dry-run", "-f", str(checkout / "Makefile"),
+                     *extra_arguments, target],
+                    cwd=external,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                require(result.returncode == 0 and
+                        str(checkout / "scripts/check-baseline.py") in result.stdout and
+                        'cd "{}"'.format(checkout) in result.stdout and
+                        "/tmp/untrusted/" not in result.stdout,
+                        "Make aliases must preserve a spaced checkout root and reject ROOT overrides",
+                        failures)
+
+        environment = os.environ.copy()
+        environment["MAKEFILE_LIST"] = "/tmp/untrusted"
+        attacks = (
+            (["make", "--dry-run", "-f", str(checkout / "Makefile"),
+              "MAKEFILE_LIST=/tmp/untrusted", "check"], None),
+            (["make", "-e", "--dry-run", "-f", str(checkout / "Makefile"), "check"],
+             environment),
+        )
+        for command, attack_environment in attacks:
+            result = subprocess.run(
+                command,
+                cwd=external,
+                env=attack_environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            require(result.returncode != 0 and
+                    "MAKEFILE_LIST must not be overridden" in result.stderr,
+                    "Makefile must fail closed when MAKEFILE_LIST is overridden",
+                    failures)
+
+
 def main():
     failures = []
     required_files = [
@@ -123,6 +181,7 @@ def main():
         "docs/plans/2026-06-16-schedule-response-revision-policy.md",
         "docs/plans/2026-06-17-location-response-revision-policy.md",
         "docs/plans/2026-06-17-ferry-coordinate-domain-validation.md",
+        "docs/plans/2026-06-21-spaced-makefile-path.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -227,6 +286,7 @@ def main():
     schedule_response_plan = read("docs/plans/2026-06-16-schedule-response-revision-policy.md")
     location_response_plan = read("docs/plans/2026-06-17-location-response-revision-policy.md")
     coordinate_domain_plan = read("docs/plans/2026-06-17-ferry-coordinate-domain-validation.md")
+    spaced_make_plan = read("docs/plans/2026-06-21-spaced-makefile-path.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -267,6 +327,7 @@ def main():
     require(makefile == EXPECTED_MAKEFILE,
             "Makefile must exactly preserve rooted standard gates and the guarded build script",
             failures)
+    check_makefile_path_resolution(makefile, failures)
 
     require(app_plist.get("NSLocationWhenInUseUsageDescription"),
             "app Info.plist must document when-in-use location permission",
@@ -720,6 +781,9 @@ def main():
     require("make -f /path/to/Larkspur-Ferry/Makefile check" in readme,
             "README must document location-independent Makefile invocation",
             failures)
+    require("paths contain spaces" in readme and "MAKEFILE_LIST" in readme,
+            "README must document spaced paths and protected Makefile metadata",
+            failures)
     require("status: completed" in plan,
             "plan must be marked completed",
             failures)
@@ -768,6 +832,11 @@ def main():
             "root and external-directory" in location_independent_make_plan and
             "six isolated hostile mutations" in location_independent_make_plan,
             "location-independent Make plan must record completed root, external, and mutation verification",
+            failures)
+    require("status: completed" in spaced_make_plan and
+            "literal apostrophe" in spaced_make_plan and
+            "MAKEFILE_LIST" in spaced_make_plan,
+            "spaced Makefile path plan must record completed hostile-path verification",
             failures)
     require("status: completed" in visible_map_plan and
             "hostile mutations" in visible_map_plan and


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: support spaced absolute Makefile paths

### Original Description

### Summary

The documented absolute `make -f` verification path used GNU Make list functions to derive the repository root. Those functions split checkout paths on whitespace, causing all four aliases to resolve scripts under the external caller directory when the checkout path contained spaces.

The Makefile now derives the root from the raw shell-quoted Makefile path, preserves the protected `override ROOT` boundary, and rejects command-line or `-e` environment replacement of `MAKEFILE_LIST`. The static baseline executes dry-run regressions for every alias from a path containing spaces, brackets, and a literal apostrophe, including hostile `ROOT` and `MAKEFILE_LIST` inputs.

## Testing

- Ran `make check`, `make lint`, `make test`, and `make build` from the hostile-path disposable checkout.
- Ran all four aliases from an unrelated directory through the absolute Makefile path with a hostile `ROOT` value.
- Confirmed command-line and environment `MAKEFILE_LIST` attacks fail closed.
- Passed the Python baseline with `SyntaxWarning` promoted to an error, POSIX shell syntax checks, and `git diff --check`.
- Linux truthfully skipped unavailable Swift, CocoaPods, and Xcode execution while the static ferry baseline and guarded build path passed.
- Scanned the staged diff for high-confidence credential/private-key patterns; no matches were found.

## Post-Deploy Monitoring & Validation

No production runtime monitoring is required because this changes repository verification path resolution only. After merge, confirm the exact merged `master` head passes the macOS `baseline` workflow and configured CodeQL jobs, including the executable schedule/location policy harnesses. Revert if verification resolves outside the checkout or any credential, signing, API, location, archive, or upload boundary regresses.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the ferry app correctness, API safety, location handling, CI, testing, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted evidence is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, signing setting, API call, location behavior, workflow, or runtime behavior.

## Follow-Ups

No additional follow-up is introduced by this metadata-only update.
