### PR TITLE
fix: preserve ferry schedule on request failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-25
+
+- Distinguished failed schedule requests from successful empty schedules so a
+  same-direction refresh failure preserves visible departures.
+- Tracked which origin owns the displayed schedule so an accepted failure after
+  a direction change clears stale departures from the previous route.
+
 ## 2026-06-21
 
 - Made absolute external Makefile invocations work when checkout paths contain

--- a/Larkspur Ferry/API.swift
+++ b/Larkspur Ferry/API.swift
@@ -38,26 +38,28 @@ final class API {
     }
     
     // MARK: Helper for Ferry
-    func getTimes(from: String, completion: @escaping ([Ferry]) -> Void) {
+    func getTimes(from: String, completion: @escaping ([Ferry]?) -> Void) {
         // Get the ferry from ...
         get(endpoint: "ferry/larkspur", parameters: ["from": from as AnyObject]) { JSON in
-            
-            var boats: [Ferry] = []
-            if let result = JSON as? JSONArray {
-                for item in result {
-                    guard let arrive = item["arrive"] as? String,
-                        let depart = item["depart"] as? String,
-                        let fromLocation = item["from"] as? String,
-                        let toLocation = item["to"] as? String else {
-                            continue
-                    }
+            guard let result = JSON as? JSONArray else {
+                completion(nil)
+                return
+            }
 
-                    let ferryBoat = Ferry(arrive: arrive,
-                                          depart: depart,
-                                          from: fromLocation,
-                                          to: toLocation)
-                    boats.append(ferryBoat)
+            var boats: [Ferry] = []
+            for item in result {
+                guard let arrive = item["arrive"] as? String,
+                    let depart = item["depart"] as? String,
+                    let fromLocation = item["from"] as? String,
+                    let toLocation = item["to"] as? String else {
+                        continue
                 }
+
+                let ferryBoat = Ferry(arrive: arrive,
+                                      depart: depart,
+                                      from: fromLocation,
+                                      to: toLocation)
+                boats.append(ferryBoat)
             }
 
             completion(boats)

--- a/Larkspur Ferry/ScheduleResponsePolicy.swift
+++ b/Larkspur Ferry/ScheduleResponsePolicy.swift
@@ -13,10 +13,20 @@ func acceptsFerryScheduleResponse(requestedFrom: String,
 }
 
 func ferryScheduleItemsToPublish<Item>(responseItems: [Item]?,
-                                       acceptsResponse: Bool) -> [Item]? {
+                                       acceptsResponse: Bool,
+                                       requestedFrom: String,
+                                       publishedFrom: String?) -> [Item]? {
     guard acceptsResponse else {
         return nil
     }
 
-    return responseItems
+    if let responseItems = responseItems {
+        return responseItems
+    }
+
+    if publishedFrom == requestedFrom {
+        return nil
+    }
+
+    return []
 }

--- a/Larkspur Ferry/ScheduleResponsePolicy.swift
+++ b/Larkspur Ferry/ScheduleResponsePolicy.swift
@@ -11,3 +11,12 @@ func acceptsFerryScheduleResponse(requestedFrom: String,
         requestedDirectionRevision == currentDirectionRevision &&
         requestedScheduleRequestRevision == currentScheduleRequestRevision
 }
+
+func ferryScheduleItemsToPublish<Item>(responseItems: [Item]?,
+                                       acceptsResponse: Bool) -> [Item]? {
+    guard acceptsResponse else {
+        return nil
+    }
+
+    return responseItems
+}

--- a/Larkspur Ferry/ViewController.swift
+++ b/Larkspur Ferry/ViewController.swift
@@ -140,19 +140,26 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
         let requestedScheduleRequestRevision = scheduleRequestRevision
         API.sharedInstance.getTimes(from: requestedFrom) { [weak self] (boats) -> Void in
             DispatchQueue.main.async {
-                guard let viewController = self,
-                    acceptsFerryScheduleResponse(
+                guard let viewController = self else {
+                    return
+                }
+
+                let acceptsResponse = acceptsFerryScheduleResponse(
                         requestedFrom: requestedFrom,
                         requestedDirectionRevision: requestedDirectionRevision,
                         requestedScheduleRequestRevision: requestedScheduleRequestRevision,
                         currentFrom: viewController.f,
                         currentDirectionRevision: viewController.directionRevision,
                         currentScheduleRequestRevision: viewController.scheduleRequestRevision
+                    )
+                guard let boatsToPublish = ferryScheduleItemsToPublish(
+                    responseItems: boats,
+                    acceptsResponse: acceptsResponse
                     ) else {
                     return
                 }
 
-                viewController.items = boats
+                viewController.items = boatsToPublish
                 viewController.tableView.reloadData()
             }
         }

--- a/Larkspur Ferry/ViewController.swift
+++ b/Larkspur Ferry/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
     var directionRevision = 0
     var locationLookupDirectionRevision = 0
     var scheduleRequestRevision = 0
+    var publishedScheduleFrom: String?
     
     var locationUpdated = false
     
@@ -154,12 +155,15 @@ class ViewController: UIViewController, CLLocationManagerDelegate,  UITableViewD
                     )
                 guard let boatsToPublish = ferryScheduleItemsToPublish(
                     responseItems: boats,
-                    acceptsResponse: acceptsResponse
+                    acceptsResponse: acceptsResponse,
+                    requestedFrom: requestedFrom,
+                    publishedFrom: viewController.publishedScheduleFrom
                     ) else {
                     return
                 }
 
                 viewController.items = boatsToPublish
+                viewController.publishedScheduleFrom = requestedFrom
                 viewController.tableView.reloadData()
             }
         }

--- a/Tests/ScheduleResponsePolicyTests/main.swift
+++ b/Tests/ScheduleResponsePolicyTests/main.swift
@@ -36,12 +36,16 @@ expect("Sausalito", 2, 4, "Sausalito", 2, 4, false, "unknown origin")
 private func expectPublishedItems(_ currentItems: [Int],
                                   _ responseItems: [Int]?,
                                   _ acceptsResponse: Bool,
+                                  _ requestedFrom: String,
+                                  _ publishedFrom: String?,
                                   _ expectedItems: [Int],
                                   _ message: String) {
     var actualItems = currentItems
     if let itemsToPublish = ferryScheduleItemsToPublish(
         responseItems: responseItems,
-        acceptsResponse: acceptsResponse
+        acceptsResponse: acceptsResponse,
+        requestedFrom: requestedFrom,
+        publishedFrom: publishedFrom
         ) {
         actualItems = itemsToPublish
     }
@@ -52,11 +56,20 @@ private func expectPublishedItems(_ currentItems: [Int],
     }
 }
 
-expectPublishedItems([9], [1, 2], true, [1, 2], "current nonempty success publishes")
-expectPublishedItems([9], [], true, [], "current empty success publishes")
-expectPublishedItems([9], nil, true, [9], "current failure preserves existing rows")
-expectPublishedItems([9], [3], false, [9], "stale success does not publish")
-expectPublishedItems([9], nil, false, [9], "stale failure does not publish")
+expectPublishedItems([9], [1, 2], true, "Larkspur", "Larkspur", [1, 2],
+                     "current nonempty success publishes")
+expectPublishedItems([9], [], true, "Larkspur", "Larkspur", [],
+                     "current empty success publishes")
+expectPublishedItems([9], nil, true, "Larkspur", "Larkspur", [9],
+                     "same-origin failure preserves existing rows")
+expectPublishedItems([9], nil, true, "San Francisco", "Larkspur", [],
+                     "changed-origin failure clears stale rows")
+expectPublishedItems([9], nil, true, "Larkspur", nil, [],
+                     "initial failure publishes an empty current schedule")
+expectPublishedItems([9], [3], false, "San Francisco", "Larkspur", [9],
+                     "stale success does not publish")
+expectPublishedItems([9], nil, false, "San Francisco", "Larkspur", [9],
+                     "stale failure does not publish")
 
 if failureCount > 0 {
     fatalError("ScheduleResponsePolicy behavioral tests failed: \(failureCount)")

--- a/Tests/ScheduleResponsePolicyTests/main.swift
+++ b/Tests/ScheduleResponsePolicyTests/main.swift
@@ -33,6 +33,31 @@ expect("Larkspur", 6, 11, "Larkspur", 6, 12, false, "newer same-origin schedule 
 expect("", 0, 1, "", 0, 1, false, "empty origin")
 expect("Sausalito", 2, 4, "Sausalito", 2, 4, false, "unknown origin")
 
+private func expectPublishedItems(_ currentItems: [Int],
+                                  _ responseItems: [Int]?,
+                                  _ acceptsResponse: Bool,
+                                  _ expectedItems: [Int],
+                                  _ message: String) {
+    var actualItems = currentItems
+    if let itemsToPublish = ferryScheduleItemsToPublish(
+        responseItems: responseItems,
+        acceptsResponse: acceptsResponse
+        ) {
+        actualItems = itemsToPublish
+    }
+
+    if actualItems != expectedItems {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expectedItems), got \(actualItems)")
+    }
+}
+
+expectPublishedItems([9], [1, 2], true, [1, 2], "current nonempty success publishes")
+expectPublishedItems([9], [], true, [], "current empty success publishes")
+expectPublishedItems([9], nil, true, [9], "current failure preserves existing rows")
+expectPublishedItems([9], [3], false, [9], "stale success does not publish")
+expectPublishedItems([9], nil, false, [9], "stale failure does not publish")
+
 if failureCount > 0 {
     fatalError("ScheduleResponsePolicy behavioral tests failed: \(failureCount)")
 }

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -42,6 +42,80 @@ def require(condition, message, failures):
         failures.append(message)
 
 
+def check_schedule_publication_contract(api, view_controller, schedule_response_policy, failures):
+    require("func getTimes(from: String, completion: @escaping ([Ferry]?) -> Void)" in api,
+            "schedule API completion must distinguish failure from a successful empty schedule",
+            failures)
+    require("guard let result = JSON as? JSONArray else {" in api and
+            "completion(nil)" in api and
+            api.find("guard let result = JSON as? JSONArray else {") < api.find("var boats: [Ferry] = []"),
+            "schedule API must report transport or top-level parse failure as nil before parsing rows",
+            failures)
+    require("func ferryScheduleItemsToPublish<Item>(responseItems: [Item]?," in schedule_response_policy and
+            "guard acceptsResponse else {" in schedule_response_policy and
+            "return responseItems" in schedule_response_policy,
+            "schedule publication policy must publish only accepted successful responses",
+            failures)
+    require("let acceptsResponse = acceptsFerryScheduleResponse(" in view_controller and
+            "guard let boatsToPublish = ferryScheduleItemsToPublish(" in view_controller and
+            "responseItems: boats" in view_controller and
+            "acceptsResponse: acceptsResponse" in view_controller and
+            "viewController.items = boatsToPublish" in view_controller,
+            "schedule callback must preserve rows on failure and publish only accepted successes",
+            failures)
+
+
+def check_schedule_publication_mutations(api, view_controller, schedule_response_policy, failures):
+    mutations = [
+        (
+            "nonoptional schedule completion",
+            api.replace("([Ferry]?) -> Void", "([Ferry]) -> Void", 1),
+            view_controller,
+            schedule_response_policy,
+        ),
+        (
+            "collapsed top-level parse failure",
+            api.replace("guard let result = JSON as? JSONArray else {", "if let result = JSON as? JSONArray {", 1),
+            view_controller,
+            schedule_response_policy,
+        ),
+        (
+            "accepted-response bypass",
+            api,
+            view_controller,
+            schedule_response_policy.replace("guard acceptsResponse else {", "if false {", 1),
+        ),
+        (
+            "failure converted to empty success",
+            api,
+            view_controller.replace(
+                "guard let boatsToPublish = ferryScheduleItemsToPublish(",
+                "let boatsToPublish = boats ?? []\n                if false { ferryScheduleItemsToPublish(",
+                1,
+            ),
+            schedule_response_policy,
+        ),
+        (
+            "direct callback publication",
+            api,
+            view_controller.replace("viewController.items = boatsToPublish", "viewController.items = boats", 1),
+            schedule_response_policy,
+        ),
+    ]
+
+    for name, mutated_api, mutated_view_controller, mutated_policy in mutations:
+        mutation_failures = []
+        check_schedule_publication_contract(
+            mutated_api,
+            mutated_view_controller,
+            mutated_policy,
+            mutation_failures,
+        )
+        require(mutation_failures,
+                "schedule publication source gate accepted mutation: " + name,
+                failures)
+
+
 def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
@@ -360,8 +434,10 @@ def main():
             "API location parsing must handle malformed payloads without force unwraps",
             failures)
     require("guard let arrive" in api and "completion(boats)" in api,
-            "API schedule parsing must skip malformed ferry rows and always complete",
+            "API schedule parsing must skip malformed ferry rows and complete successful arrays",
             failures)
+    check_schedule_publication_contract(api, view_controller, schedule_response_policy, failures)
+    check_schedule_publication_mutations(api, view_controller, schedule_response_policy, failures)
     require("parameters?.stringFromHttpParameters() ?? \"\"" in api and "guard let url = URL" in api,
             "API request builder must avoid force-unwrapping parameters and URLs",
             failures)
@@ -439,9 +515,14 @@ def main():
         'false, "newer same-origin schedule request"',
         'false, "empty origin"',
         'false, "unknown origin"',
+        '"current nonempty success publishes"',
+        '"current empty success publishes"',
+        '"current failure preserves existing rows"',
+        '"stale success does not publish"',
+        '"stale failure does not publish"',
     )
     require(all(schedule_response_tests.count(fragment) == 1 for fragment in test_contract),
-            "executable schedule response tests must preserve all nine behavioral cases",
+            "executable schedule response tests must preserve revision and publication behavior",
             failures)
     require("requestedRevision == currentRevision" in location_response_policy,
             "production location response policy must require the current request revision",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -53,15 +53,19 @@ def check_schedule_publication_contract(api, view_controller, schedule_response_
             failures)
     require("func ferryScheduleItemsToPublish<Item>(responseItems: [Item]?," in schedule_response_policy and
             "guard acceptsResponse else {" in schedule_response_policy and
-            "return responseItems" in schedule_response_policy,
-            "schedule publication policy must publish only accepted successful responses",
+            "publishedFrom == requestedFrom" in schedule_response_policy and
+            "return []" in schedule_response_policy,
+            "schedule publication policy must preserve only same-origin failures",
             failures)
     require("let acceptsResponse = acceptsFerryScheduleResponse(" in view_controller and
             "guard let boatsToPublish = ferryScheduleItemsToPublish(" in view_controller and
             "responseItems: boats" in view_controller and
             "acceptsResponse: acceptsResponse" in view_controller and
-            "viewController.items = boatsToPublish" in view_controller,
-            "schedule callback must preserve rows on failure and publish only accepted successes",
+            "requestedFrom: requestedFrom" in view_controller and
+            "publishedFrom: viewController.publishedScheduleFrom" in view_controller and
+            "viewController.items = boatsToPublish" in view_controller and
+            "viewController.publishedScheduleFrom = requestedFrom" in view_controller,
+            "schedule callback must track which origin owns displayed rows",
             failures)
 
 
@@ -84,6 +88,12 @@ def check_schedule_publication_mutations(api, view_controller, schedule_response
             api,
             view_controller,
             schedule_response_policy.replace("guard acceptsResponse else {", "if false {", 1),
+        ),
+        (
+            "cross-origin failure preserved",
+            api,
+            view_controller,
+            schedule_response_policy.replace("return []", "return nil", 1),
         ),
         (
             "failure converted to empty success",
@@ -517,7 +527,9 @@ def main():
         'false, "unknown origin"',
         '"current nonempty success publishes"',
         '"current empty success publishes"',
-        '"current failure preserves existing rows"',
+        '"same-origin failure preserves existing rows"',
+        '"changed-origin failure clears stale rows"',
+        '"initial failure publishes an empty current schedule"',
         '"stale success does not publish"',
         '"stale failure does not publish"',
     )


### PR DESCRIPTION
## Summary
- distinguish schedule request/top-level parse failure from a valid empty timetable
- preserve displayed rows on current failure while still clearing them on successful empty results
- retain existing stale-response, direction, and malformed-row behavior

## Validation
- portable schedule/location behavior suites
- five hostile mutation gates and baseline checks
- external-root Make gate, Swift 4 parsing/typechecking, project parsing
- independent hostile review of the exact commit/tree: GO

## Validation boundary
The legacy Swift 3 / CocoaPods / Alamofire app target is not compiled locally or in hosted CI; the checked-in workflow intentionally uses `SKIP_XCODE_BUILD=1`. This PR preserves that disclosed limitation. Auto-merge is intentionally disabled.