### PR TITLE
docs: define transit data freshness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-25
 
+- Documented the legacy transit proxy, schedule and map request cadence,
+  uncached 10-second request boundary, retained-data behavior, and absence of a
+  server timestamp or freshness guarantee.
 - Distinguished failed schedule requests from successful empty schedules so a
   same-direction refresh failure preserves visible departures.
 - Tracked which origin owns the displayed schedule so an accepted failure after

--- a/DATA_SOURCE.md
+++ b/DATA_SOURCE.md
@@ -1,0 +1,47 @@
+# Transit Data Source And Freshness
+
+This repository is a legacy sample. Its checked-in `API.swift` sends requests
+to `https://requestlabs.appspot.com/`, a project-specific proxy endpoint that
+is not identified in this repository as an official Golden Gate Ferry data
+source. The repository does not identify the proxy's upstream provider, update
+process, owner, service-level expectations, or continued availability.
+
+## Request Surfaces
+
+- Schedule rows come from `ferry/larkspur?from=` with the selected origin set to
+  either `Larkspur` or `San Francisco`. The app requests a schedule during its
+  initial direction flow and after the user changes direction; it does not run
+  a periodic schedule refresh.
+- The map requests `ferry/location?t=1` immediately when the map appears and
+  every 30 seconds while the map is visible. Polling stops when the map begins
+  disappearing.
+
+Both request paths use `reloadIgnoringLocalCacheData`, require a successful JSON
+response, and use a 10-second request timeout. These client controls avoid a
+local URL-cache response and bound each attempt, but they do not prove that the
+proxy or its upstream data is current.
+
+## Freshness Boundary
+
+The response shape does not expose a server timestamp, feed version, source
+attribution, or last-updated value. The app therefore has no freshness guarantee
+for schedule rows or ferry coordinates and cannot display the age of accepted
+data.
+
+On a same-direction schedule failure, the app preserves already visible rows;
+after a direction change, it clears rows owned by the previous origin. A failed
+map refresh preserves the last known ferry pin. Those continuity behaviors are
+not evidence that retained data remains current.
+
+Treat all displayed information as sample output. Verify current service
+information independently before travel using an authoritative transit source.
+Do not use this app for operational, safety-critical, or accessibility planning.
+
+## Maintenance Rules
+
+- Document any endpoint, response-shape, polling, timeout, caching, or retained
+  data change in this file and `CHANGES.md`.
+- Keep source attribution factual; do not present the legacy proxy as an
+  official or real-time feed without verifiable evidence.
+- Add fixture or policy coverage before changing how stale, failed, or
+  direction-mismatched responses are published.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This README is based on the checked-in source, manifests, scripts, and repositor
 - `Podfile.lock` - Apple platform dependency metadata
 - `scripts/check-baseline.py` - static Swift/API/location baseline checks
 - `SECURITY.md` - security reporting and disclosure guidance
+- `DATA_SOURCE.md` - current transit endpoint and freshness boundaries
 - `VISION.md` - project direction and maintenance guardrails
 
 Additional scan context:
@@ -58,6 +59,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - Open `Larkspur Ferry.xcworkspace` in Xcode after `pod install`, choose the app or sample scheme, and run it on the matching simulator/device.
 - Run `./build.sh` when the required platform toolchain is installed.
+- Read [`DATA_SOURCE.md`](DATA_SOURCE.md) before relying on displayed schedule
+  or ferry-location data. The checked-in legacy proxy is not documented as an
+  official source, exposes no server timestamp, and provides no freshness
+  guarantee.
 - `build.sh` skips cleanly on hosts without CocoaPods or Xcode so static checks can run on non-macOS machines.
 - The map refresh timer starts while the map screen is visible and is invalidated when the screen disappears.
 - An in-flight map response is discarded after the map screen disappears, so

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,9 @@ Priority:
 
 - Preserve ferry schedule and map-location flows
 - Keep API endpoint behavior visible and documented
+- Keep the legacy transit proxy, request cadence, retained-data behavior, and
+  lack of a server timestamp documented without implying official or real-time
+  data
 - Validate successful JSON ferry responses with a 10-second uncached request
 - Keep API request construction on deterministic query parameter ordering
 - Keep locale-independent coordinate parsing for ferry API latitude and longitude values
@@ -58,7 +61,8 @@ Next priorities:
 - Move API base URL into documented configuration
 - Add tests or fixtures for schedule parsing and location handling
 - Modernize Swift, Alamofire, and project settings in a dedicated pass
-- Document current transit-data source and freshness expectations
+- Require endpoint or refresh changes to update the transit-data source and
+  freshness contract
 
 Contribution rules:
 

--- a/docs/plans/2026-06-25-transit-data-source-freshness.md
+++ b/docs/plans/2026-06-25-transit-data-source-freshness.md
@@ -33,8 +33,10 @@ publication behavior.
 - `python3 -m py_compile scripts/check-baseline.py`, the guarded
   `SKIP_XCODE_BUILD=1 ./build.sh` path, and `git diff --check` passed locally.
 - This Linux host has neither `swiftc` nor Xcode and retains the repository's
-  pre-existing `/bin/sh` Make-root incompatibility. Exact-head hosted macOS
-  `make check` is required before merge.
+  pre-existing `/bin/sh` Make-root incompatibility.
+- Exact-head hosted macOS `make check` passed on both push and pull-request
+  runs, including the Swift policy harnesses, static baseline, and guarded
+  legacy build boundary. CodeQL Actions and Python analysis also passed.
 
 ## Residual Risk
 

--- a/docs/plans/2026-06-25-transit-data-source-freshness.md
+++ b/docs/plans/2026-06-25-transit-data-source-freshness.md
@@ -1,0 +1,44 @@
+# Transit Data Source And Freshness Documentation
+
+Status: completed
+
+## Scope
+
+Complete the bounded roadmap item for current transit-data source and freshness
+expectations without changing the legacy endpoint, request cadence, parsing, or
+publication behavior.
+
+## Work Completed
+
+- Record the project-specific proxy base URL and both checked-in request paths.
+- Distinguish user-triggered schedule loading from 30-second visible-map
+  location polling.
+- Explain the uncached 10-second client request boundary without presenting it
+  as proof of upstream freshness.
+- Document missing server timestamps, attribution, feed versions, and freshness
+  guarantees.
+- Explain when failed requests retain prior schedule rows or the last known
+  ferry pin and why retained data must not be treated as current.
+
+## Verification Completed
+
+- Cross-checked the documented base URL, request paths, 10-second timeout,
+  uncached request policy, and 30-second map cadence against the checked-in
+  Swift source.
+- Confirmed the baseline checker failed for every missing guide, link, roadmap,
+  and plan contract before the documentation was added.
+- Thirteen isolated hostile documentation mutations were rejected for source,
+  cadence, cache, timeout, timestamp, freshness, travel-warning, link, roadmap,
+  and completed-plan drift.
+- `python3 -m py_compile scripts/check-baseline.py`, the guarded
+  `SKIP_XCODE_BUILD=1 ./build.sh` path, and `git diff --check` passed locally.
+- This Linux host has neither `swiftc` nor Xcode and retains the repository's
+  pre-existing `/bin/sh` Make-root incompatibility. Exact-head hosted macOS
+  `make check` is required before merge.
+
+## Residual Risk
+
+The proxy's upstream provider, ownership, update process, and continued
+availability are not identified in this repository. Documentation cannot make
+the legacy endpoint authoritative; travelers must verify current information
+independently.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -236,6 +236,7 @@ def main():
         ".github/workflows/check.yml",
         ".travis.yml",
         "CHANGES.md",
+        "DATA_SOURCE.md",
         "Makefile",
         "Podfile",
         "Podfile.lock",
@@ -266,6 +267,7 @@ def main():
         "docs/plans/2026-06-17-location-response-revision-policy.md",
         "docs/plans/2026-06-17-ferry-coordinate-domain-validation.md",
         "docs/plans/2026-06-21-spaced-makefile-path.md",
+        "docs/plans/2026-06-25-transit-data-source-freshness.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -345,6 +347,7 @@ def main():
     vision = read("VISION.md")
     security = read("SECURITY.md")
     changes = read("CHANGES.md")
+    data_source = read("DATA_SOURCE.md") if (ROOT / "DATA_SOURCE.md").exists() else ""
     makefile = read("Makefile")
     overview = read("docs/readme-overview.svg")
     gitignore = read(".gitignore")
@@ -371,6 +374,8 @@ def main():
     location_response_plan = read("docs/plans/2026-06-17-location-response-revision-policy.md")
     coordinate_domain_plan = read("docs/plans/2026-06-17-ferry-coordinate-domain-validation.md")
     spaced_make_plan = read("docs/plans/2026-06-21-spaced-makefile-path.md")
+    data_source_plan_path = ROOT / "docs/plans/2026-06-25-transit-data-source-freshness.md"
+    data_source_plan = data_source_plan_path.read_text(encoding="utf-8", errors="replace") if data_source_plan_path.exists() else ""
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -958,6 +963,31 @@ def main():
     require("in-flight map response" in readme.lower() and
             "in-flight ferry location responses" in changes.lower(),
             "README and CHANGES must document off-screen map response rejection",
+            failures)
+    normalized_data_source = " ".join(data_source.split())
+    for phrase in [
+        "https://requestlabs.appspot.com/",
+        "ferry/larkspur?from=",
+        "ferry/location?t=1",
+        "not identified in this repository as an official Golden Gate Ferry data source",
+        "reloadIgnoringLocalCacheData",
+        "10-second request timeout",
+        "every 30 seconds while the map is visible",
+        "does not expose a server timestamp",
+        "no freshness guarantee",
+        "verify current service information independently before travel",
+    ]:
+        require(phrase.lower() in normalized_data_source.lower(),
+                f"DATA_SOURCE.md must document {phrase}", failures)
+    require("[`DATA_SOURCE.md`](DATA_SOURCE.md)" in readme,
+            "README must link the transit data source guide", failures)
+    require("Document current transit-data source and freshness expectations" not in vision,
+            "VISION must not retain the completed transit-data documentation priority",
+            failures)
+    require("status: completed" in data_source_plan.lower() and
+            "make check" in data_source_plan.lower() and
+            "hostile documentation mutations" in data_source_plan.lower(),
+            "transit data source plan must record completed verification",
             failures)
     workflow_files = sorted(
         path.relative_to(ROOT).as_posix()


### PR DESCRIPTION
## Summary
- document the legacy transit proxy, schedule and location request surfaces, and polling cadence
- explain the uncached 10-second client boundary, missing server timestamps, and lack of a freshness guarantee
- preserve the documentation contract in the static baseline and close the corresponding roadmap item

## Local validation
- 13 isolated hostile documentation mutations rejected
- `python3 -m py_compile scripts/check-baseline.py`
- `SKIP_XCODE_BUILD=1 ./build.sh`
- `git diff --check`
- baseline has no data-source contract failures; this Linux host retains the documented pre-existing `/bin/sh` Make-root incompatibility and has no Swift/Xcode toolchain

## Required before merge
- exact-head hosted macOS `make check`
- CodeQL
