### PR TITLE
Configure and validate the ferry API base URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 2026-06-26
+
+- Moved the ferry API base URL from a private Swift literal into the checked-in
+  `FerryAPIBaseURL` plist setting while preserving the current proxy endpoint.
+- Added a fail-closed URL policy and executable Swift coverage for missing,
+  blank, non-string, insecure, hostless, credential-bearing, query-bearing,
+  fragment-bearing, whitespace-padded, and missing-slash configuration values.
+- Wired the policy into the app target and every Make verification alias, and
+  documented the endpoint configuration and transit-data maintenance rules.
+- Repaired the existing Make root resolver so its apostrophe-path contract runs
+  under POSIX shells instead of emitting a bad-substitution error.
+
 ## 2026-06-25
 
 - Documented the legacy transit proxy, schedule and map request cadence,

--- a/DATA_SOURCE.md
+++ b/DATA_SOURCE.md
@@ -1,10 +1,11 @@
 # Transit Data Source And Freshness
 
 This repository is a legacy sample. Its checked-in `API.swift` sends requests
-to `https://requestlabs.appspot.com/`, a project-specific proxy endpoint that
-is not identified in this repository as an official Golden Gate Ferry data
-source. The repository does not identify the proxy's upstream provider, update
-process, owner, service-level expectations, or continued availability.
+to the `FerryAPIBaseURL` value in `Larkspur Ferry/Info.plist`. The checked-in
+value is `https://requestlabs.appspot.com/`, a project-specific proxy endpoint
+that is not identified in this repository as an official Golden Gate Ferry
+data source. The repository does not identify the proxy's upstream provider,
+update process, owner, service-level expectations, or continued availability.
 
 ## Request Surfaces
 
@@ -39,6 +40,9 @@ Do not use this app for operational, safety-critical, or accessibility planning.
 
 ## Maintenance Rules
 
+- Keep `FerryAPIBaseURL` absolute, HTTPS-only, credential-free, and free of a
+  query string or fragment. Invalid or missing configuration stops requests
+  before Alamofire is called.
 - Document any endpoint, response-shape, polling, timeout, caching, or retained
   data change in this file and `CHANGES.md`.
 - Keep source attribution factual; do not present the legacy proxy as an

--- a/Larkspur Ferry.xcodeproj/project.pbxproj
+++ b/Larkspur Ferry.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */; };
 		A17061711C04445D009A6111 /* LocationResponsePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17061721C04445D009A6111 /* LocationResponsePolicy.swift */; };
+		A26062611C04445D009A6111 /* APIBaseURLPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26062621C04445D009A6111 /* APIBaseURLPolicy.swift */; };
 		886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886EA3C31C1F918F00E864A0 /* FerryCell.swift */; };
 		8899B7881C037F6D00512759 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8899B7871C037F6D00512759 /* CoreLocation.framework */; };
 		889C7DD21C04445D009A6111 /* Ferry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C7DD11C04445D009A6111 /* Ferry.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleResponsePolicy.swift; sourceTree = "<group>"; };
 		A17061721C04445D009A6111 /* LocationResponsePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationResponsePolicy.swift; sourceTree = "<group>"; };
+		A26062621C04445D009A6111 /* APIBaseURLPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIBaseURLPolicy.swift; sourceTree = "<group>"; };
 		3AFC5927A49D0AA110B3C5FB /* Pods-Larkspur Ferry.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Larkspur Ferry.release.xcconfig"; path = "Pods/Target Support Files/Pods-Larkspur Ferry/Pods-Larkspur Ferry.release.xcconfig"; sourceTree = "<group>"; };
 		886EA3C31C1F918F00E864A0 /* FerryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FerryCell.swift; sourceTree = "<group>"; };
 		8899B7871C037F6D00512759 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -127,6 +129,7 @@
 				88CBBCE81C037B1F000D263E /* AppDelegate.swift */,
 				A16061621C04445D009A6111 /* ScheduleResponsePolicy.swift */,
 				A17061721C04445D009A6111 /* LocationResponsePolicy.swift */,
+				A26062621C04445D009A6111 /* APIBaseURLPolicy.swift */,
 				88CBBCEA1C037B1F000D263E /* ViewController.swift */,
 				889C7DD11C04445D009A6111 /* Ferry.swift */,
 				88C12B591A54CCC9006DA21E /* API.swift */,
@@ -315,6 +318,7 @@
 			files = (
 				A16061611C04445D009A6111 /* ScheduleResponsePolicy.swift in Sources */,
 				A17061711C04445D009A6111 /* LocationResponsePolicy.swift in Sources */,
+				A26062611C04445D009A6111 /* APIBaseURLPolicy.swift in Sources */,
 				889C7DD21C04445D009A6111 /* Ferry.swift in Sources */,
 				88FD06CB1C0A7EC500EA6A9F /* Extensions.swift in Sources */,
 				886EA3C41C1F918F00E864A0 /* FerryCell.swift in Sources */,

--- a/Larkspur Ferry/API.swift
+++ b/Larkspur Ferry/API.swift
@@ -16,7 +16,9 @@ private typealias JSONObject = NSDictionary
 // MARK: API class to hold API requests
 final class API {
     static let sharedInstance = API()
-    private let apiBaseURL = "https://requestlabs.appspot.com/"
+    private let apiBaseURL = validatedFerryAPIBaseURL(
+        Bundle.main.object(forInfoDictionaryKey: ferryAPIBaseURLInfoKey)
+    )
     private let requestTimeout: TimeInterval = 10
     
     // MARK: Helper for Ferry
@@ -93,7 +95,8 @@ final class API {
         let parameterString = parameters?.stringFromHttpParameters() ?? ""
         let querySuffix = parameterString.isEmpty ? "" : "?\(parameterString)"
 
-        guard let url = URL(string: apiBaseURL + endpoint + querySuffix) else {
+        guard let apiBaseURL = apiBaseURL,
+            let url = URL(string: endpoint + querySuffix, relativeTo: apiBaseURL)?.absoluteURL else {
             completion(nil)
             return
         }

--- a/Larkspur Ferry/APIBaseURLPolicy.swift
+++ b/Larkspur Ferry/APIBaseURLPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+let ferryAPIBaseURLInfoKey = "FerryAPIBaseURL"
+
+func validatedFerryAPIBaseURL(_ rawValue: Any?) -> URL? {
+    guard let configuredValue = rawValue as? String else {
+        return nil
+    }
+
+    let trimmedValue = configuredValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedValue.isEmpty,
+        var components = URLComponents(string: trimmedValue),
+        components.scheme?.lowercased() == "https",
+        let host = components.host,
+        !host.isEmpty,
+        components.user == nil,
+        components.password == nil,
+        components.query == nil,
+        components.fragment == nil else {
+            return nil
+    }
+
+    components.scheme = "https"
+    if !components.path.hasSuffix("/") {
+        components.path += "/"
+    }
+
+    return components.url
+}

--- a/Larkspur Ferry/Info.plist
+++ b/Larkspur Ferry/Info.plist
@@ -20,6 +20,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>10</string>
+	<key>FerryAPIBaseURL</key>
+	<string>https://requestlabs.appspot.com/</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$${path\# }; dirname -- "$$path")
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | sed 's/^ //'); dirname -- "$$path")
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test
@@ -10,6 +10,7 @@ lint test build: check
 
 check:
 	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh"; \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \
 	else \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   or ferry-location data. The checked-in legacy proxy is not documented as an
   official source, exposes no server timestamp, and provides no freshness
   guarantee.
+- Configure that proxy through the `FerryAPIBaseURL` key in
+  `Larkspur Ferry/Info.plist`. The app accepts only an absolute HTTPS URL with a
+  host and no embedded credentials, query string, or fragment; missing or
+  invalid configuration fails closed before Alamofire request construction.
 - `build.sh` skips cleanly on hosts without CocoaPods or Xcode so static checks can run on non-macOS machines.
 - The map refresh timer starts while the map screen is visible and is invalidated when the screen disappears.
 - An in-flight map response is discarded after the map screen disappears, so

--- a/Tests/APIBaseURLPolicyTests/main.swift
+++ b/Tests/APIBaseURLPolicyTests/main.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+private var failureCount = 0
+
+private func expect(_ rawValue: Any?, _ expected: String?, _ message: String) {
+    let actual = validatedFerryAPIBaseURL(rawValue)?.absoluteString
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(String(describing: expected)), got \(String(describing: actual))")
+    }
+}
+
+expect("https://requestlabs.appspot.com/",
+       "https://requestlabs.appspot.com/",
+       "current HTTPS endpoint")
+expect("  https://example.com/ferry/  ",
+       "https://example.com/ferry/",
+       "surrounding whitespace")
+expect("https://example.com/ferry",
+       "https://example.com/ferry/",
+       "missing trailing slash")
+expect(nil, nil, "missing configuration")
+expect(42, nil, "non-string configuration")
+expect("", nil, "empty configuration")
+expect("   ", nil, "blank configuration")
+expect("http://example.com/", nil, "insecure scheme")
+expect("ftp://example.com/", nil, "unsupported scheme")
+expect("https:///ferry/", nil, "missing host")
+expect("https://user:secret@example.com/", nil, "embedded credentials")
+expect("https://example.com/ferry/?token=secret", nil, "query string")
+expect("https://example.com/ferry/#section", nil, "fragment")
+
+if failureCount > 0 {
+    exit(1)
+}
+
+print("API base URL policy tests passed")

--- a/VISION.md
+++ b/VISION.md
@@ -13,10 +13,11 @@ Project context lives in [`README.md`](README.md).
 The goal is to keep the app useful, verifiable, and clear about its data source.
 
 Current baseline: `make lint`, `make test`, `make build`, and `make check` run
-the revision-aware schedule response harness, `scripts/check-baseline.py`, and
-the guarded `build.sh` path to verify the production callback decision, build
-script, CocoaPods metadata, Swift API parsing, single-shot location fallbacks,
-project assets, generated metadata ignores, and documentation.
+the API base URL, schedule response, and location response Swift harnesses,
+`scripts/check-baseline.py`, and the guarded `build.sh` path to verify the
+production callback decisions, build script, CocoaPods metadata, Swift API
+parsing, single-shot location fallbacks, project assets, generated metadata
+ignores, and documentation.
 
 The current focus is:
 
@@ -55,10 +56,11 @@ Priority:
   `SKIP_XCODE_BUILD=1` legacy-build boundary
 - Maintain screenshot, build script, and UI test context
 - Avoid committing private endpoints, keys, or generated signing files
+- Keep the configured ferry API base URL HTTPS-only, credential-free, and
+  covered by the standalone Swift policy harness
 
 Next priorities:
 
-- Move API base URL into documented configuration
 - Add tests or fixtures for schedule parsing and location handling
 - Modernize Swift, Alamofire, and project settings in a dedicated pass
 - Require endpoint or refresh changes to update the transit-data source and

--- a/docs/plans/2026-06-26-configurable-api-base-url.md
+++ b/docs/plans/2026-06-26-configurable-api-base-url.md
@@ -1,0 +1,69 @@
+# Configurable API Base URL Implementation Plan
+
+Status: completed
+
+## Goal
+
+Move the legacy ferry proxy base URL from a private source literal into
+documented app configuration without allowing malformed, insecure, or
+credential-bearing endpoint values to reach Alamofire.
+
+## Design
+
+- Add `FerryAPIBaseURL` to the checked-in app `Info.plist`, preserving the
+  current `https://requestlabs.appspot.com/` behavior by default.
+- Resolve the value through a Foundation-only policy that accepts a nonblank
+  absolute HTTPS URL with a host and no user, password, query, or fragment.
+- Normalize a missing trailing slash so the existing relative request paths
+  remain stable.
+- Fail closed before request construction when configuration is absent or
+  invalid.
+- Exercise the production policy with a standalone Swift harness from every
+  Make verification alias.
+- Repair the pre-existing POSIX-shell failure in the apostrophe-path Make root
+  guard discovered while running the required full gate.
+- Document configuration, validation, and transit-data maintenance rules.
+
+## Verification
+
+1. Run the focused Swift harness before implementation and observe compiler
+   failure because `APIBaseURLPolicy.swift` does not exist.
+2. Implement the policy and runtime wiring, then rerun the focused harness.
+3. Extend the static baseline and hostile mutation coverage for source,
+   project, plist, documentation, and completed-plan drift.
+4. Run all Make aliases, the guarded build path, and `git diff --check`.
+5. Require exact-head hosted validation before merge.
+
+## Risks
+
+- A missing or malformed deployed plist value now prevents requests instead of
+  silently using a hidden source default; the checked-in plist supplies the
+  current value.
+- The legacy proxy remains unauthenticated and without a freshness guarantee;
+  this change only makes endpoint ownership explicit.
+
+## Work Completed
+
+- Added the checked-in `FerryAPIBaseURL` plist setting and removed the private
+  endpoint literal from `API.swift`.
+- Added a Foundation-only validation policy, app-target wiring, and a
+  standalone executable Swift test harness.
+- Updated the README, transit-data guide, vision, changelog, project file,
+  Make authority contract, and static baseline.
+- Replaced the Make root resolver's shell-invalid escaped parameter expansion
+  with a quoted POSIX `sed` trim while preserving hostile-path behavior.
+
+## Verification Completed
+
+- The RED container run failed because `APIBaseURLPolicy.swift` did not exist.
+- The focused policy and both existing response-policy harnesses passed under
+  cached Swift 5.10, 6.0, and 6.2 containers.
+- Ten isolated hostile mutations were rejected for scheme, host, user,
+  password, query, fragment, bundle lookup, plist, project-source, and Make
+  runner weakening.
+- All four Make gates passed from the repository root, and the absolute
+  external Makefile gate passed from a hostile path containing spaces, an
+  apostrophe, and brackets.
+- Python compilation, plist parsing, guarded legacy build behavior, and
+  `git diff --check` passed. Xcode and CocoaPods execution remain delegated to
+  exact-head hosted macOS validation.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -18,7 +18,7 @@ PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 EXPECTED_MAKEFILE = """ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$${path\\# }; dirname -- "$$path")
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | sed 's/^ //'); dirname -- "$$path")
 SWIFTC ?= swiftc
 
 .PHONY: build check lint test
@@ -27,6 +27,7 @@ lint test build: check
 
 check:
 \t@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \\
+\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh"; \\
 \t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \\
 \t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \\
 \telse \\
@@ -40,6 +41,94 @@ check:
 def require(condition, message, failures):
     if not condition:
         failures.append(message)
+
+
+def check_api_base_url_contract(policy, api, project, plist_text, makefile,
+                                runner, tests, readme, data_source, vision,
+                                plan, failures):
+    for phrase in [
+        'let ferryAPIBaseURLInfoKey = "FerryAPIBaseURL"',
+        'components.scheme?.lowercased() == "https"',
+        "let host = components.host",
+        "!host.isEmpty",
+        "components.user == nil",
+        "components.password == nil",
+        "components.query == nil",
+        "components.fragment == nil",
+        'components.path.hasSuffix("/")',
+    ]:
+        require(phrase in policy,
+                "API base URL policy must preserve: " + phrase,
+                failures)
+    require("Bundle.main.object(forInfoDictionaryKey: ferryAPIBaseURLInfoKey)" in api and
+            "guard let apiBaseURL = apiBaseURL," in api and
+            "relativeTo: apiBaseURL" in api,
+            "API requests must use only the validated bundle configuration",
+            failures)
+    require("<key>FerryAPIBaseURL</key>" in plist_text and
+            "<string>https://requestlabs.appspot.com/</string>" in plist_text,
+            "app plist must declare the reviewed ferry API base URL",
+            failures)
+    require(project.count("/* APIBaseURLPolicy.swift */") == 3 and
+            project.count("/* APIBaseURLPolicy.swift in Sources */") == 2,
+            "APIBaseURLPolicy.swift must remain a unique app-target source",
+            failures)
+    require("run-api-base-url-policy-tests.sh" in makefile and
+            "Larkspur Ferry/APIBaseURLPolicy.swift" in runner and
+            "Tests/APIBaseURLPolicyTests/main.swift" in runner,
+            "every Make gate must execute the production API base URL policy",
+            failures)
+    for phrase in [
+        "missing configuration",
+        "non-string configuration",
+        "insecure scheme",
+        "missing host",
+        "embedded credentials",
+        "query string",
+        "fragment",
+        "missing trailing slash",
+    ]:
+        require(phrase in tests,
+                "API base URL tests must cover " + phrase,
+                failures)
+    require("FerryAPIBaseURL" in readme and
+            "FerryAPIBaseURL" in data_source and
+            "HTTPS-only" in vision,
+            "project guidance must document validated endpoint configuration",
+            failures)
+    require("status: completed" in plan.lower() and
+            "hostile mutations" in plan.lower() and
+            "all four make gates" in plan.lower(),
+            "API base URL plan must record completed verification",
+            failures)
+
+
+def check_api_base_url_mutations(policy, api, project, plist_text, makefile,
+                                 runner, tests, readme, data_source, vision,
+                                 plan, failures):
+    mutations = [
+        ("insecure scheme", policy.replace('== "https"', '== "http"', 1), api, project, plist_text, makefile, runner),
+        ("missing host guard", policy.replace("!host.isEmpty,", "true,", 1), api, project, plist_text, makefile, runner),
+        ("embedded user allowed", policy.replace("components.user == nil,", "true,", 1), api, project, plist_text, makefile, runner),
+        ("embedded password allowed", policy.replace("components.password == nil,", "true,", 1), api, project, plist_text, makefile, runner),
+        ("query allowed", policy.replace("components.query == nil,", "true,", 1), api, project, plist_text, makefile, runner),
+        ("fragment allowed", policy.replace("components.fragment == nil", "true", 1), api, project, plist_text, makefile, runner),
+        ("bundle lookup bypass", policy, api.replace("Bundle.main.object", "Bundle().object", 1), project, plist_text, makefile, runner),
+        ("plist key removed", policy, api, project, plist_text.replace("FerryAPIBaseURL", "RemovedAPIBaseURL", 1), makefile, runner),
+        ("project source removed", policy, api, project.replace("APIBaseURLPolicy.swift in Sources", "RemovedPolicy.swift in Sources"), plist_text, makefile, runner),
+        ("Make runner removed", policy, api, project, plist_text, makefile.replace("run-api-base-url-policy-tests.sh", "removed-policy-tests.sh", 1), runner),
+    ]
+
+    for name, mutated_policy, mutated_api, mutated_project, mutated_plist, mutated_makefile, mutated_runner in mutations:
+        mutation_failures = []
+        check_api_base_url_contract(
+            mutated_policy, mutated_api, mutated_project, mutated_plist,
+            mutated_makefile, mutated_runner, tests, readme, data_source,
+            vision, plan, mutation_failures,
+        )
+        require(mutation_failures,
+                "API base URL source gate accepted mutation: " + name,
+                failures)
 
 
 def check_schedule_publication_contract(api, view_controller, schedule_response_policy, failures):
@@ -268,6 +357,7 @@ def main():
         "docs/plans/2026-06-17-ferry-coordinate-domain-validation.md",
         "docs/plans/2026-06-21-spaced-makefile-path.md",
         "docs/plans/2026-06-25-transit-data-source-freshness.md",
+        "docs/plans/2026-06-26-configurable-api-base-url.md",
         "docs/readme-overview.svg",
         "Screenshots/screenshot01.png",
         "Larkspur Ferry.xcworkspace/contents.xcworkspacedata",
@@ -277,6 +367,7 @@ def main():
         "Larkspur Ferry.xcodeproj/xcshareddata/xcschemes/Larkspur FerryUITests.xcscheme",
         "Larkspur Ferry/Info.plist",
         "Larkspur Ferry/API.swift",
+        "Larkspur Ferry/APIBaseURLPolicy.swift",
         "Larkspur Ferry/Extensions.swift",
         "Larkspur Ferry/ScheduleResponsePolicy.swift",
         "Larkspur Ferry/LocationResponsePolicy.swift",
@@ -292,8 +383,10 @@ def main():
         "Larkspur FerryUITests/SnapshotHelper.swift",
         "Tests/ScheduleResponsePolicyTests/main.swift",
         "Tests/LocationResponsePolicyTests/main.swift",
+        "Tests/APIBaseURLPolicyTests/main.swift",
         "scripts/run-schedule-response-policy-tests.sh",
         "scripts/run-location-response-policy-tests.sh",
+        "scripts/run-api-base-url-policy-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -327,18 +420,22 @@ def main():
         check_png(image_file, failures)
 
     app_plist = parse_plist("Larkspur Ferry/Info.plist", failures)
+    app_plist_text = read("Larkspur Ferry/Info.plist")
     test_plist = parse_plist("Larkspur FerryUITests/Info.plist", failures)
     project = read("Larkspur Ferry.xcodeproj/project.pbxproj")
     build_script = read("build.sh")
     api = read("Larkspur Ferry/API.swift")
+    api_base_url_policy = read("Larkspur Ferry/APIBaseURLPolicy.swift")
     extensions = read("Larkspur Ferry/Extensions.swift")
     schedule_response_policy = read("Larkspur Ferry/ScheduleResponsePolicy.swift")
     location_response_policy = read("Larkspur Ferry/LocationResponsePolicy.swift")
     view_controller = read("Larkspur Ferry/ViewController.swift")
     schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
     location_response_tests = read("Tests/LocationResponsePolicyTests/main.swift")
+    api_base_url_tests = read("Tests/APIBaseURLPolicyTests/main.swift")
     schedule_response_runner = read("scripts/run-schedule-response-policy-tests.sh")
     location_response_runner = read("scripts/run-location-response-policy-tests.sh")
+    api_base_url_runner = read("scripts/run-api-base-url-policy-tests.sh")
     map_controller = read("Larkspur Ferry/MapViewController.swift")
     pin_annotation = read("Larkspur Ferry/PinAnnotation.swift")
     app_swift = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
@@ -376,6 +473,7 @@ def main():
     spaced_make_plan = read("docs/plans/2026-06-21-spaced-makefile-path.md")
     data_source_plan_path = ROOT / "docs/plans/2026-06-25-transit-data-source-freshness.md"
     data_source_plan = data_source_plan_path.read_text(encoding="utf-8", errors="replace") if data_source_plan_path.exists() else ""
+    api_base_url_plan = read("docs/plans/2026-06-26-configurable-api-base-url.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -403,6 +501,16 @@ def main():
     )
     require(location_runner_shell_result.returncode == 0,
             "location response runner must pass POSIX shell syntax checks: " + location_runner_shell_result.stderr.strip(),
+            failures)
+    api_base_url_runner_shell_result = subprocess.run(
+        ["sh", "-n", "scripts/run-api-base-url-policy-tests.sh"],
+        cwd=str(ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    require(api_base_url_runner_shell_result.returncode == 0,
+            "API base URL runner must pass POSIX shell syntax checks: " + api_base_url_runner_shell_result.stderr.strip(),
             failures)
     require("function ci_build" not in build_script and "ci_build() {" in build_script and "ci_test() {" in build_script,
             "build.sh must use POSIX-compatible shell function syntax",
@@ -438,12 +546,23 @@ def main():
             project.count("/* LocationResponsePolicy.swift in Sources */") == 2,
             "LocationResponsePolicy.swift must remain a unique app-target source",
             failures)
+    check_api_base_url_contract(
+        api_base_url_policy, api, project, app_plist_text, makefile,
+        api_base_url_runner, api_base_url_tests, readme, data_source, vision,
+        api_base_url_plan, failures,
+    )
+    check_api_base_url_mutations(
+        api_base_url_policy, api, project, app_plist_text, makefile,
+        api_base_url_runner, api_base_url_tests, readme, data_source, vision,
+        api_base_url_plan, failures,
+    )
     require("Alamofire', '~> 4.0'" in podfile and "Alamofire (4.3.0)" in podlock,
             "Podfile and lockfile must preserve the pinned Alamofire baseline",
             failures)
 
-    require('private let apiBaseURL = "https://requestlabs.appspot.com/"' in api,
-            "API base URL must remain HTTPS and visible",
+    require("validatedFerryAPIBaseURL(" in api and
+            app_plist.get("FerryAPIBaseURL") == "https://requestlabs.appspot.com/",
+            "API base URL must remain HTTPS, configured, and visible",
             failures)
     require("completion(nil)" in api and "guard let result = JSON as? JSONObject" in api,
             "API location parsing must handle malformed payloads without force unwraps",
@@ -453,7 +572,8 @@ def main():
             failures)
     check_schedule_publication_contract(api, view_controller, schedule_response_policy, failures)
     check_schedule_publication_mutations(api, view_controller, schedule_response_policy, failures)
-    require("parameters?.stringFromHttpParameters() ?? \"\"" in api and "guard let url = URL" in api,
+    require("parameters?.stringFromHttpParameters() ?? \"\"" in api and
+            "let url = URL(string: endpoint + querySuffix, relativeTo: apiBaseURL)?.absoluteURL" in api,
             "API request builder must avoid force-unwrapping parameters and URLs",
             failures)
     require("private let requestTimeout: TimeInterval = 10" in api and

--- a/scripts/run-api-base-url-policy-tests.sh
+++ b/scripts/run-api-base-url-policy-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/larkspur-api-base-url-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/Larkspur Ferry/APIBaseURLPolicy.swift" \
+    "$ROOT/Tests/APIBaseURLPolicyTests/main.swift" \
+    -o "$BUILD_DIR/api-base-url-policy-tests"
+
+"$BUILD_DIR/api-base-url-policy-tests"


### PR DESCRIPTION
## Summary
- Move the legacy ferry proxy base URL into the checked-in `FerryAPIBaseURL` plist setting.
- Validate configured endpoints as absolute, HTTPS-only, host-bearing, credential-free URLs without query strings or fragments.
- Run the production policy from every Make gate and document the configuration boundary.
- Repair the pre-existing POSIX-shell failure in the hostile apostrophe-path Make-root check discovered during validation.

## Baseline
The API base URL was hard-coded in Swift, preventing reviewed environment configuration and leaving no reusable fail-closed policy for malformed or unsafe endpoint values.

## Improvements
The app now reads a checked-in plist value through a dedicated policy that rejects missing, non-string, non-HTTPS, hostless, credential-bearing, queried, or fragmented URLs and normalizes a trailing slash before relative endpoint construction.

## Validation
- API, schedule, and location Swift harnesses on Swift 5.10, 6.0, and 6.2 containers.
- `make lint`
- `make test`
- `make build`
- `make check`
- External absolute Makefile invocation.
- Ten hostile API-base contract mutations.
- `python3 -m py_compile scripts/check-baseline.py`
- Plist parsing and `git diff --check`.

## Risk
Xcode and CocoaPods execution is delegated to the hosted macOS check because this host does not provide those tools. The checked-in default still points to a legacy proxy whose availability and data freshness remain operational dependencies.

## Follow-Ups
Keep the plist value and policy under review, preserve fail-closed URL validation, and revalidate the configured provider's ownership, TLS, availability, and freshness before production use.
