### PR TITLE
fix: reject all-malformed ferry schedules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 2026-06-26 20:42 PDT - P1 - Reject all-malformed schedules
+
+- Prevented a nonempty provider array with zero parseable ferry rows from being
+  reported as a successful empty timetable and clearing valid displayed rows;
+  the all-malformed schedule response now follows the request-failure path.
+- Preserved genuine empty arrays and mixed payloads containing at least one
+  valid ferry row.
+- Added executable schedule policy cases for empty, valid, mixed,
+  all-malformed, negative, and impossible row counts.
+- Added static and hostile mutation coverage for the production parser guard,
+  policy invariant, documentation, and completed implementation plan.
+- Swift 5.10, 6.0, and 6.2 policy execution, the static baseline, all four root
+  Make aliases, and the absolute external Makefile gate pass. Hosted macOS
+  project parsing and CodeQL remain required before merge.
+
 ## 2026-06-26
 
 - Moved the ferry API base URL from a private Swift literal into the checked-in

--- a/DATA_SOURCE.md
+++ b/DATA_SOURCE.md
@@ -22,6 +22,11 @@ response, and use a 10-second request timeout. These client controls avoid a
 local URL-cache response and bound each attempt, but they do not prove that the
 proxy or its upstream data is current.
 
+Schedule parsing accepts a genuine empty array and retains valid rows from a
+mixed payload. An all-malformed schedule response is treated as request failure
+so invalid provider data cannot masquerade as an empty timetable and erase
+same-direction departures that were already displayed.
+
 ## Freshness Boundary
 
 The response shape does not expose a server timestamp, feed version, source
@@ -49,3 +54,5 @@ Do not use this app for operational, safety-critical, or accessibility planning.
   official or real-time feed without verifiable evidence.
 - Add fixture or policy coverage before changing how stale, failed, or
   direction-mismatched responses are published.
+- Preserve the empty, mixed, and all-malformed schedule response distinctions
+  in the executable schedule policy harness.

--- a/Larkspur Ferry/API.swift
+++ b/Larkspur Ferry/API.swift
@@ -64,6 +64,14 @@ final class API {
                 boats.append(ferryBoat)
             }
 
+            guard acceptsParsedFerrySchedule(
+                originalRowCount: result.count,
+                parsedRowCount: boats.count
+                ) else {
+                completion(nil)
+                return
+            }
+
             completion(boats)
         }
     }

--- a/Larkspur Ferry/ScheduleResponsePolicy.swift
+++ b/Larkspur Ferry/ScheduleResponsePolicy.swift
@@ -30,3 +30,14 @@ func ferryScheduleItemsToPublish<Item>(responseItems: [Item]?,
 
     return []
 }
+
+func acceptsParsedFerrySchedule(originalRowCount: Int,
+                                parsedRowCount: Int) -> Bool {
+    guard originalRowCount >= 0,
+        parsedRowCount >= 0,
+        parsedRowCount <= originalRowCount else {
+        return false
+    }
+
+    return originalRowCount == 0 || parsedRowCount > 0
+}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Schedule table times use POSIX schedule time parsing for fixed-format ferry API values.
 - Live ferry requests bypass cached data, time out after 10 seconds, and accept
   only successful `application/json` responses before parsing.
+- An all-malformed schedule response is treated as a failed request instead of
+  a successful empty schedule; a genuinely empty array remains valid, and
+  mixed arrays retain their valid rows.
 - Schedule table and map API callbacks use main-thread UI updates before
   mutating UIKit or MapKit state.
 - Revision-aware ferry-location callbacks ignore older overlapping responses
@@ -97,7 +100,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 ## Testing and Verification
 
 - `make lint`, `make test`, `make build`, and `make check` execute the production
-  schedule and ferry-location response policies when `swiftc` is available,
+  schedule parsing/publication and ferry-location response policies when
+  `swiftc` is available,
   then run
   `scripts/check-baseline.py` and the guarded `build.sh` path. The checker
   preserves both executable harnesses, app-target wiring, API and location

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,8 @@ Helpful reports include:
 - The app uses an HTTPS ferry API endpoint and CoreLocation for in-app direction assistance. API and location failures should fall back without force-unwrapping or app debug logging.
 - Live ferry requests should bypass cached responses, use a 10-second timeout,
   and validate HTTP success plus `application/json` before parsing.
+- An all-malformed schedule response must fail closed rather than clear valid
+  displayed departures as though the provider returned a genuine empty array.
 - Deterministic query parameter encoding should run after percent encoding so request construction is stable during review.
 - Locale-independent coordinate parsing should handle ferry API latitude and longitude strings consistently across device regions.
 - Ferry coordinates must be finite and remain within valid latitude and

--- a/Tests/ScheduleResponsePolicyTests/main.swift
+++ b/Tests/ScheduleResponsePolicyTests/main.swift
@@ -71,6 +71,29 @@ expectPublishedItems([9], [3], false, "San Francisco", "Larkspur", [9],
 expectPublishedItems([9], nil, false, "San Francisco", "Larkspur", [9],
                      "stale failure does not publish")
 
+private func expectParsedSchedule(_ originalRowCount: Int,
+                                  _ parsedRowCount: Int,
+                                  _ expected: Bool,
+                                  _ message: String) {
+    let actual = acceptsParsedFerrySchedule(
+        originalRowCount: originalRowCount,
+        parsedRowCount: parsedRowCount
+    )
+
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expected), got \(actual)")
+    }
+}
+
+expectParsedSchedule(0, 0, true, "empty provider schedule")
+expectParsedSchedule(2, 2, true, "all valid provider rows")
+expectParsedSchedule(3, 1, true, "mixed provider rows retain valid entries")
+expectParsedSchedule(2, 0, false, "all malformed provider rows")
+expectParsedSchedule(-1, 0, false, "negative original row count")
+expectParsedSchedule(1, -1, false, "negative parsed row count")
+expectParsedSchedule(1, 2, false, "parsed rows exceed original rows")
+
 if failureCount > 0 {
     fatalError("ScheduleResponsePolicy behavioral tests failed: \(failureCount)")
 }

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,8 @@ Priority:
   lack of a server timestamp documented without implying official or real-time
   data
 - Validate successful JSON ferry responses with a 10-second uncached request
+- Treat an all-malformed schedule response as failure while preserving genuine
+  empty arrays and valid rows from mixed payloads
 - Keep API request construction on deterministic query parameter ordering
 - Keep locale-independent coordinate parsing for ferry API latitude and longitude values
 - Reject non-finite and out-of-range ferry coordinates before MapKit publication
@@ -61,7 +63,7 @@ Priority:
 
 Next priorities:
 
-- Add tests or fixtures for schedule parsing and location handling
+- Add further fixtures for location payload handling
 - Modernize Swift, Alamofire, and project settings in a dedicated pass
 - Require endpoint or refresh changes to update the transit-data source and
   freshness contract

--- a/docs/plans/2026-06-26-all-malformed-schedule-response.md
+++ b/docs/plans/2026-06-26-all-malformed-schedule-response.md
@@ -1,0 +1,60 @@
+# All-Malformed Schedule Response Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve valid displayed schedule rows when a nonempty provider array contains no parseable ferry rows.
+
+**Architecture:** Extend the existing Foundation-free schedule response policy with a count-based payload acceptance rule. Empty arrays remain valid empty schedules, mixed arrays retain valid rows, and nonempty arrays with zero valid rows become request failures before publication policy runs.
+
+**Tech Stack:** Swift 3-compatible policy code, standalone `swiftc` harnesses, Python static/mutation contracts, GNU Make, hosted Xcode validation.
+
+---
+
+Status: Completed
+
+### Task 1: Add the failing payload-policy tests
+
+**Files:**
+- Modify: `Tests/ScheduleResponsePolicyTests/main.swift`
+
+Add cases for an empty valid array, all-valid rows, mixed valid/malformed rows,
+all-malformed rows, and impossible negative or over-count inputs.
+
+Run: `scripts/run-schedule-response-policy-tests.sh`
+Expected: compile failure because `acceptsParsedFerrySchedule` does not exist.
+
+### Task 2: Implement and wire the policy
+
+**Files:**
+- Modify: `Larkspur Ferry/ScheduleResponsePolicy.swift`
+- Modify: `Larkspur Ferry/API.swift`
+
+Implement `acceptsParsedFerrySchedule(originalRowCount:parsedRowCount:)` and
+return `nil` from `getTimes` when a nonempty array produces zero valid boats.
+Keep empty arrays and partial valid parsing behavior unchanged.
+
+Run: `scripts/run-schedule-response-policy-tests.sh`
+Expected: all schedule policy tests pass.
+
+### Task 3: Preserve contracts and evidence
+
+**Files:**
+- Modify: `scripts/check-baseline.py`
+- Modify: `CHANGES.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `DATA_SOURCE.md`
+
+Add source and hostile mutation coverage, document the provider-data boundary,
+and mark the existing schedule-fixture roadmap priority complete.
+
+Run: `make check`
+Expected: all Swift policy harnesses and baseline mutations pass; guarded Xcode
+validation skips locally only when its documented toolchain is unavailable.
+
+Observed: API base URL, schedule response, and location response policy
+harnesses pass under cached Swift 5.10, 6.0, and 6.2 containers. The static
+baseline, Python and shell syntax, `git diff --check`, all four root Make aliases,
+and the absolute external Makefile gate pass with `SKIP_XCODE_BUILD=1`; hosted
+macOS remains authoritative for project parsing.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -146,6 +146,17 @@ def check_schedule_publication_contract(api, view_controller, schedule_response_
             "return []" in schedule_response_policy,
             "schedule publication policy must preserve only same-origin failures",
             failures)
+    require("func acceptsParsedFerrySchedule(originalRowCount: Int," in schedule_response_policy and
+            "parsedRowCount <= originalRowCount" in schedule_response_policy and
+            "return originalRowCount == 0 || parsedRowCount > 0" in schedule_response_policy,
+            "schedule payload policy must accept empty or partially valid arrays and reject all-malformed arrays",
+            failures)
+    require("guard acceptsParsedFerrySchedule(" in api and
+            "originalRowCount: result.count" in api and
+            "parsedRowCount: boats.count" in api and
+            api.find("guard acceptsParsedFerrySchedule(") < api.find("completion(boats)"),
+            "schedule parsing must reject all-malformed nonempty arrays before reporting success",
+            failures)
     require("let acceptsResponse = acceptsFerryScheduleResponse(" in view_controller and
             "guard let boatsToPublish = ferryScheduleItemsToPublish(" in view_controller and
             "responseItems: boats" in view_controller and
@@ -198,6 +209,22 @@ def check_schedule_publication_mutations(api, view_controller, schedule_response
             "direct callback publication",
             api,
             view_controller.replace("viewController.items = boatsToPublish", "viewController.items = boats", 1),
+            schedule_response_policy,
+        ),
+        (
+            "all-malformed payload accepted",
+            api,
+            view_controller,
+            schedule_response_policy.replace(
+                "return originalRowCount == 0 || parsedRowCount > 0",
+                "return true",
+                1,
+            ),
+        ),
+        (
+            "payload acceptance bypassed",
+            api.replace("guard acceptsParsedFerrySchedule(", "if false && acceptsParsedFerrySchedule(", 1),
+            view_controller,
             schedule_response_policy,
         ),
     ]
@@ -428,9 +455,9 @@ def main():
     api_base_url_policy = read("Larkspur Ferry/APIBaseURLPolicy.swift")
     extensions = read("Larkspur Ferry/Extensions.swift")
     schedule_response_policy = read("Larkspur Ferry/ScheduleResponsePolicy.swift")
+    schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
     location_response_policy = read("Larkspur Ferry/LocationResponsePolicy.swift")
     view_controller = read("Larkspur Ferry/ViewController.swift")
-    schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
     location_response_tests = read("Tests/LocationResponsePolicyTests/main.swift")
     api_base_url_tests = read("Tests/APIBaseURLPolicyTests/main.swift")
     schedule_response_runner = read("scripts/run-schedule-response-policy-tests.sh")
@@ -474,6 +501,7 @@ def main():
     data_source_plan_path = ROOT / "docs/plans/2026-06-25-transit-data-source-freshness.md"
     data_source_plan = data_source_plan_path.read_text(encoding="utf-8", errors="replace") if data_source_plan_path.exists() else ""
     api_base_url_plan = read("docs/plans/2026-06-26-configurable-api-base-url.md")
+    malformed_schedule_plan = read("docs/plans/2026-06-26-all-malformed-schedule-response.md")
     workflow = read(".github/workflows/check.yml")
     annotation_plan_path = ROOT / "docs/plans/2026-06-08-map-annotation-refresh.md"
     annotation_plan = annotation_plan_path.read_text(encoding="utf-8", errors="replace") if annotation_plan_path.exists() else ""
@@ -556,6 +584,11 @@ def main():
         api_base_url_runner, api_base_url_tests, readme, data_source, vision,
         api_base_url_plan, failures,
     )
+    require("status: completed" in malformed_schedule_plan.lower() and
+            "all-malformed" in malformed_schedule_plan.lower() and
+            "make check" in malformed_schedule_plan,
+            "all-malformed schedule response plan must record completed verification",
+            failures)
     require("Alamofire', '~> 4.0'" in podfile and "Alamofire (4.3.0)" in podlock,
             "Podfile and lockfile must preserve the pinned Alamofire baseline",
             failures)
@@ -567,11 +600,24 @@ def main():
     require("completion(nil)" in api and "guard let result = JSON as? JSONObject" in api,
             "API location parsing must handle malformed payloads without force unwraps",
             failures)
-    require("guard let arrive" in api and "completion(boats)" in api,
-            "API schedule parsing must skip malformed ferry rows and complete successful arrays",
+    require("guard let arrive" in api and "completion(boats)" in api and
+            "acceptsParsedFerrySchedule" in api,
+            "API schedule parsing must skip malformed rows without accepting an all-malformed array",
             failures)
     check_schedule_publication_contract(api, view_controller, schedule_response_policy, failures)
     check_schedule_publication_mutations(api, view_controller, schedule_response_policy, failures)
+    require("all malformed provider rows" in schedule_response_tests and
+            "empty provider schedule" in schedule_response_tests and
+            "mixed provider rows retain valid entries" in schedule_response_tests,
+            "schedule policy tests must distinguish empty, partial, and all-malformed arrays",
+            failures)
+    require("all-malformed schedule response" in readme.lower() and
+            "all-malformed schedule response" in security.lower() and
+            "all-malformed schedule response" in vision.lower() and
+            "all-malformed schedule response" in data_source.lower() and
+            "all-malformed schedule response" in changes.lower(),
+            "project guidance must document all-malformed schedule response handling",
+            failures)
     require("parameters?.stringFromHttpParameters() ?? \"\"" in api and
             "let url = URL(string: endpoint + querySuffix, relativeTo: apiBaseURL)?.absoluteURL" in api,
             "API request builder must avoid force-unwrapping parameters and URLs",


### PR DESCRIPTION
## Summary
- reject nonempty schedule arrays when every provider row is malformed
- preserve genuine empty schedules and valid rows from mixed payloads
- extend the production schedule policy harness and hostile source contracts

## Regression
`API.getTimes` previously skipped malformed rows and always completed with the parsed array. A nonempty payload containing zero valid rows therefore became a successful empty schedule, which could clear previously valid same-direction departures.

## Validation
- RED: Swift 5.10 harness failed because `acceptsParsedFerrySchedule` was absent
- API base URL, schedule response, and location response policy harnesses pass under Swift 5.10, 6.0, and 6.2
- all four root Make aliases pass with `SKIP_XCODE_BUILD=1`
- absolute external Makefile `check` passes
- Python and shell syntax pass
- static baseline and hostile mutations pass
- `git diff --check`

## Boundary
The legacy proxy still exposes no timestamp or freshness guarantee. This change only prevents structurally invalid schedule data from masquerading as a valid empty timetable.

## Review
- `codex review --base origin/master` was attempted on exact head `8f1d4cd8a7c74f71b2f429b2703354a841ed8e31` and failed before analysis with OpenAI HTTP 401.
- Immutable manual exact-head review found no actionable empty-array, partial-row, failure-publication, or parser-count issue.
