### PR TITLE
fix: strip Swift comments before asserting contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,15 @@ SWIFTC ?= swiftc
 
 lint test build: check
 
+# The three policy suites are &&-chained, not `;`-chained. Make runs recipes via `sh -c`
+# with no `set -e`, so a `;`-separated list inside this if-block exits with the status of
+# only its LAST command: a failure in the api-base-url or schedule suite was discarded and
+# the target still succeeded. Verified in isolation -- a recipe of the identical shape whose
+# first two commands exit 1 and whose last exits 0 gives `make` exit 0.
 check:
 	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
-		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh"; \
-		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh" && \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh" && \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \
 	else \
 		echo "swiftc unavailable; executable response policy tests skipped"; \

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -246,8 +246,80 @@ def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
-def strip_swift_line_comments(text):
-    return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
+# Ported verbatim from ios-app-share's check-baseline.py, the working reference in
+# this account: a real scanner handling nested /* */ blocks, string-aware and
+# escape-aware.
+#
+# strip_swift_line_comments split each line on "//" and nothing else -- it missed
+# /* */ entirely, and would truncate a string containing a URL. It was also applied
+# at only 3 call sites, none of them the contract checks, so every source assertion
+# below read raw text. A block-commented guard therefore satisfied its own
+# assertion while the code was dead.
+#
+# Verified: block-commenting the acceptsParsedFerrySchedule guard in API.swift left
+# `make check` at exit 0 with all three asserted literals byte-identical inside the
+# comment, while deleting the same guard IS caught ("schedule parsing must reject
+# all-malformed nonempty arrays before reporting success"). The gate was live but
+# blind. API.swift matters most here: the swiftc runners compile only
+# ScheduleResponsePolicy, LocationResponsePolicy and APIBaseURLPolicy, so API.swift
+# has no executable backstop at all.
+def strip_swift_comments(text):
+    result = []
+    index = 0
+    block_depth = 0
+    in_string = False
+    escaped = False
+
+    while index < len(text):
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+
+        if block_depth:
+            if character == "/" and next_character == "*":
+                block_depth += 1
+                index += 2
+                continue
+            if character == "*" and next_character == "/":
+                block_depth -= 1
+                index += 2
+                continue
+            if character == "\n":
+                result.append(character)
+            index += 1
+            continue
+
+        if in_string:
+            result.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if character == '"':
+            in_string = True
+            result.append(character)
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            newline = text.find("\n", index + 2)
+            if newline == -1:
+                break
+            result.append("\n")
+            index = newline + 1
+            continue
+        if character == "/" and next_character == "*":
+            block_depth = 1
+            index += 2
+            continue
+
+        result.append(character)
+        index += 1
+
+    return "".join(result)
 
 
 def parse_xml(relative_path, failures):
@@ -451,21 +523,21 @@ def main():
     test_plist = parse_plist("Larkspur FerryUITests/Info.plist", failures)
     project = read("Larkspur Ferry.xcodeproj/project.pbxproj")
     build_script = read("build.sh")
-    api = read("Larkspur Ferry/API.swift")
-    api_base_url_policy = read("Larkspur Ferry/APIBaseURLPolicy.swift")
-    extensions = read("Larkspur Ferry/Extensions.swift")
-    schedule_response_policy = read("Larkspur Ferry/ScheduleResponsePolicy.swift")
-    schedule_response_tests = read("Tests/ScheduleResponsePolicyTests/main.swift")
-    location_response_policy = read("Larkspur Ferry/LocationResponsePolicy.swift")
-    view_controller = read("Larkspur Ferry/ViewController.swift")
-    location_response_tests = read("Tests/LocationResponsePolicyTests/main.swift")
-    api_base_url_tests = read("Tests/APIBaseURLPolicyTests/main.swift")
+    api = strip_swift_comments(read("Larkspur Ferry/API.swift"))
+    api_base_url_policy = strip_swift_comments(read("Larkspur Ferry/APIBaseURLPolicy.swift"))
+    extensions = strip_swift_comments(read("Larkspur Ferry/Extensions.swift"))
+    schedule_response_policy = strip_swift_comments(read("Larkspur Ferry/ScheduleResponsePolicy.swift"))
+    schedule_response_tests = strip_swift_comments(read("Tests/ScheduleResponsePolicyTests/main.swift"))
+    location_response_policy = strip_swift_comments(read("Larkspur Ferry/LocationResponsePolicy.swift"))
+    view_controller = strip_swift_comments(read("Larkspur Ferry/ViewController.swift"))
+    location_response_tests = strip_swift_comments(read("Tests/LocationResponsePolicyTests/main.swift"))
+    api_base_url_tests = strip_swift_comments(read("Tests/APIBaseURLPolicyTests/main.swift"))
     schedule_response_runner = read("scripts/run-schedule-response-policy-tests.sh")
     location_response_runner = read("scripts/run-location-response-policy-tests.sh")
     api_base_url_runner = read("scripts/run-api-base-url-policy-tests.sh")
-    map_controller = read("Larkspur Ferry/MapViewController.swift")
-    pin_annotation = read("Larkspur Ferry/PinAnnotation.swift")
-    app_swift = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
+    map_controller = strip_swift_comments(read("Larkspur Ferry/MapViewController.swift"))
+    pin_annotation = strip_swift_comments(read("Larkspur Ferry/PinAnnotation.swift"))
+    app_swift = "\n".join(strip_swift_comments(path.read_text(encoding="utf-8", errors="replace"))
                           for path in sorted((ROOT / "Larkspur Ferry").glob("*.swift")))
     readme = read("README.md")
     vision = read("VISION.md")
@@ -632,7 +704,7 @@ def main():
             api.find(".validate(statusCode: 200..<300)") < api.find(".responseJSON"),
             "API responses must validate successful status and JSON content before parsing",
             failures)
-    require("print(" not in strip_swift_line_comments(api),
+    require("print(" not in api,
             "API source must not print network failures",
             failures)
     require("guard let keyString" in extensions and "String(describing: value)" in extensions,
@@ -782,7 +854,15 @@ def main():
             "location handling must reset lookup state, ignore repeated updates, and use a shared schedule fallback",
             failures)
     tap_start = view_controller.find("func imageTapped(tapGestureRecognizer: UITapGestureRecognizer)")
-    tap_end = view_controller.find("// UITableView", tap_start)
+    # Bound the tap body with the next declaration rather than the "// UITableView"
+    # section comment that used to delimit it. Comments are stripped before these
+    # assertions now, so a comment delimiter resolves to -1 and fails the clean
+    # tree. Anchoring on real code is also what the surrounding checks already do
+    # (location_lookup_end uses "func loadScheduleWithoutLocation()").
+    tap_end = view_controller.find(
+        "func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int)",
+        tap_start,
+    )
     tap_body = view_controller[tap_start:tap_end]
     tap_revision = tap_body.find("directionRevision += 1")
     tap_direction = tap_body.find('if self.f == "Larkspur"')
@@ -820,7 +900,7 @@ def main():
             mark_complete_index < stop_updates_index < last_location_index < fallback_index,
             "empty location updates must stop CoreLocation before schedule fallback",
             failures)
-    require("print(" not in strip_swift_line_comments(view_controller),
+    require("print(" not in view_controller,
             "app location flow must not print debug output",
             failures)
     require("guard let location = location" in map_controller and "as? CustomPointAnnotation" in map_controller,

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -157,7 +157,15 @@ def check_schedule_publication_contract(api, view_controller, schedule_response_
     # an all-malformed schedule reports success again. API.swift has no executable backstop
     # (the swiftc runners compile only the three *Policy.swift files), so this static check
     # is its only coverage. Contiguous-literal form as used by EXPECTED_MAKEFILE above.
+    #
+    # The pin must be ANCHORED to the statement it follows. A pin covering only the guard is
+    # still defeated by wrapping it: `if false {` + the guard verbatim + `}` keeps the pinned
+    # literal byte-for-byte intact while the guard never runs. Anchoring to the parse loop's
+    # closing brace means any wrapper inserted before the guard breaks the literal.
     schedule_guard = (
+        "                boats.append(ferryBoat)\n"
+        "            }\n"
+        "\n"
         "            guard acceptsParsedFerrySchedule(\n"
         "                originalRowCount: result.count,\n"
         "                parsedRowCount: boats.count\n"

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,10 +25,15 @@ SWIFTC ?= swiftc
 
 lint test build: check
 
+# The three policy suites are &&-chained, not `;`-chained. Make runs recipes via `sh -c`
+# with no `set -e`, so a `;`-separated list inside this if-block exits with the status of
+# only its LAST command: a failure in the api-base-url or schedule suite was discarded and
+# the target still succeeded. Verified in isolation -- a recipe of the identical shape whose
+# first two commands exit 1 and whose last exits 0 gives `make` exit 0.
 check:
 \t@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \\
-\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh"; \\
-\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh"; \\
+\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-api-base-url-policy-tests.sh" && \\
+\t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-schedule-response-policy-tests.sh" && \\
 \t\tSWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-location-response-policy-tests.sh"; \\
 \telse \\
 \t\techo "swiftc unavailable; executable response policy tests skipped"; \\

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -151,10 +151,23 @@ def check_schedule_publication_contract(api, view_controller, schedule_response_
             "return originalRowCount == 0 || parsedRowCount > 0" in schedule_response_policy,
             "schedule payload policy must accept empty or partially valid arrays and reject all-malformed arrays",
             failures)
-    require("guard acceptsParsedFerrySchedule(" in api and
-            "originalRowCount: result.count" in api and
-            "parsedRowCount: boats.count" in api and
-            api.find("guard acceptsParsedFerrySchedule(") < api.find("completion(boats)"),
+    # Pin the whole guard construct, not its fragments. Fragment presence plus an ordering
+    # index cannot distinguish a live guard from a dead one: appending `|| true` to the
+    # condition keeps every asserted literal byte-identical and the ordering intact while
+    # an all-malformed schedule reports success again. API.swift has no executable backstop
+    # (the swiftc runners compile only the three *Policy.swift files), so this static check
+    # is its only coverage. Contiguous-literal form as used by EXPECTED_MAKEFILE above.
+    schedule_guard = (
+        "            guard acceptsParsedFerrySchedule(\n"
+        "                originalRowCount: result.count,\n"
+        "                parsedRowCount: boats.count\n"
+        "                ) else {\n"
+        "                completion(nil)\n"
+        "                return\n"
+        "            }\n"
+    )
+    require(schedule_guard in api and
+            api.find(schedule_guard) < api.find("completion(boats)"),
             "schedule parsing must reject all-malformed nonempty arrays before reporting success",
             failures)
     require("let acceptsResponse = acceptsFerryScheduleResponse(" in view_controller and


### PR DESCRIPTION
## Problem

`strip_swift_line_comments` split each line on `//` and nothing else:

```python
def strip_swift_line_comments(text):
    return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
```

It **missed `/* */` entirely**, would **truncate a string containing a URL**, and was applied at only **3 call sites — none of them the contract checks**. Every source assertion read raw text, so a block-commented guard satisfies its own assertion while the code is dead.

## Reproduction

Block-commented the `acceptsParsedFerrySchedule` guard in `API.swift`, all three asserted literals left byte-identical inside the comment:

```
make check exit 0
Larkspur Ferry baseline checks passed.
```

**Control, proving the gate is live rather than dead** — deleting the same guard outright **is** caught:

```
schedule parsing must reject all-malformed nonempty arrays before reporting success
exit 2
```

## Why `API.swift` is the worst place for this

The `swiftc` runners compile only `ScheduleResponsePolicy.swift`, `LocationResponsePolicy.swift`, and `APIBaseURLPolicy.swift`. **`API.swift` has no executable backstop at all** — this static gate is its only check.

Worth stating the other side fairly: `APIBaseURLPolicy.swift` **is** genuinely compiled and tested in CI (`Tests/APIBaseURLPolicyTests/main.swift` contains `expect("http://example.com/", nil, "insecure scheme")`), so the equivalent gap *there* does have a backstop. I couldn't run it — no Swift toolchain — so I'm not claiming it catches this, only that it exists.

## Fix — ported, not invented

Ported **`ios-app-share`'s scanner verbatim**: the working reference in this account — handles **nested** `/* */`, string-aware, escape-aware. Routed all **11** Swift reads through it.

## One consequence worth flagging

`tap_end` was delimited by a **comment**:

```python
tap_end = view_controller.find("// UITableView", tap_start)
```

Once comments are stripped that resolves to `-1` and **failed the clean tree**. I re-anchored it on the next declaration — which is what the surrounding checks already do (`location_lookup_end` uses `func loadScheduleWithoutLocation()`).

Bounding a function body with a comment is fragile independently of this change: any reformatting or comment edit silently changes what's checked. This is the second repo in this account where a comment served as a structural delimiter, so it's worth knowing about.

## Verification

| Mutation | Applied | Result |
|---|---|---|
| clean tree | — | exit **0**, `Larkspur Ferry baseline checks passed.` |
| `acceptsParsedFerrySchedule` guard, **block** comment | 1 | **CAUGHT** — `must reject all-malformed nonempty arrays before reporting success` |
| `acceptsParsedFerrySchedule` guard, **line** comment | 1 | **CAUGHT** |

## Severity and honest bounds

**The shipped code is correct** — this is a verification gap, not a live defect. The guard works today.

**What I could not verify:** no `swift`/`swiftc`/`xcodebuild`/`pod` on this host, so I compiled no Swift and ran none of the three `swiftc` policy test binaries. Every result above is a real run of the Python gate, which is what runs on Linux.

## Cleared while here — please don't "fix" these

- **HTTP timeout is present** — `requestTimeout: TimeInterval = 10` with `urlRequest.timeoutInterval = requestTimeout`.
- **`Info.plist` parsed** (via `plistlib`, not grepped): `NSAppTransportSecurity` = absent, so **no ATS bypass**; `FerryAPIBaseURL` = `https://requestlabs.appspot.com/`; privacy string present.
- **The three Swift policy test files are genuine and non-tautological** — they cover every `APIBaseURLPolicy` guard by inspection. That's the healthy pattern; the gap is that only 3 of 11 sources get it.
- No committed secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
